### PR TITLE
fix typings for TypeScript

### DIFF
--- a/types/dist/Checkout.d.ts
+++ b/types/dist/Checkout.d.ts
@@ -8,7 +8,8 @@ export type config = {
 };
 
 type options = {
-    timeout: number;
+    pk: string,
+    timeout?: number;
 };
 
 export default class Checkout {


### PR DESCRIPTION
While using this sdk with TypeScript, the type definitions do not match the docs shown here:
https://checkout.github.io/checkout-sdk-node/initialize

It requires a `pk` but not necessarily a `timeout` for initialising in constructor (of course, correct me if I'm wrong). Hope that makes sense. Very small PR 😄 