### PR TITLE
feat: add http_code for 408

### DIFF
--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -11,6 +11,7 @@ export class ApiTimeout extends Error {
     constructor() {
         super('ApiTimeout');
         Object.setPrototypeOf(this, new.target.prototype);
+        this.http_code = 408;
         this.name = 'ApiTimeout';
     }
 }

--- a/test/payments/requestPayment.js
+++ b/test/payments/requestPayment.js
@@ -687,6 +687,7 @@ describe('Request a payment or payout', () => {
             });
         } catch (err) {
             expect(err.name).to.equal('ApiTimeout');
+            expect(err.http_code).to.equal(408);
         }
     });
 


### PR DESCRIPTION
While handling errors using the SDK, we use `http_code`, all error types have http_code apart from `ApiTimeout`