### PR TITLE
FIX: adding statusCode for ApiError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "checkout-sdk-node",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "description": "",
     "main": "./dist/index.js",
     "devDependencies": {

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -163,11 +163,12 @@ export class BadGateway extends Error {
  * @extends {Error}
  */
 export class ApiError extends Error {
-    constructor(error) {
+    constructor(http_code, message) {
         super('API Error');
         Object.setPrototypeOf(this, new.target.prototype);
         this.name = 'API Error';
-        this.body = error;
+        this.http_code = http_code;
+        this.body = message;
     }
 }
 
@@ -224,7 +225,7 @@ export const determineError = async (err) => {
         case 502:
             return new BadGateway();
         default: {
-            return new ApiError(await errorJSON);
+            return new ApiError(err.status, await errorJSON);
         }
     }
 };

--- a/test/errors/apiError.js
+++ b/test/errors/apiError.js
@@ -1,0 +1,40 @@
+import { Checkout } from '../../src/index';
+import { expect } from 'chai';
+import nock from 'nock';
+
+const PK = 'pk_test_4296fd52-efba-4a38-b6ce-cf0d93639d8a';
+
+describe('Handling Errors', () => {
+    const mockErrorResponse = { error: true };
+    const mockErrorCode = 500;
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it('should handle API error', async() => {
+        nock('https://api.sandbox.checkout.com')
+            .post('/tokens')
+            .reply(mockErrorCode, mockErrorResponse);
+
+        const cko = new Checkout({ pk: PK });
+        let errorWasThrown = false;
+
+        try {
+            await cko.tokens.request({
+                type: 'card',
+                number: '4242424242424242',
+                expiry_month: 6,
+                expiry_year: 2029,
+                cvv: '100'
+            });
+        } catch(error) {
+            errorWasThrown = true;
+
+            expect(error.http_code).to.equal(mockErrorCode);   
+            expect(error.body).to.deep.equal(mockErrorResponse);
+        }
+
+        expect(errorWasThrown).to.equal(true);
+    });
+});


### PR DESCRIPTION
Status code was not provided when unknown error occurred, e.g. Gateway returns 503 or similar.