### PR TITLE
feat: enabling passing additional headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "checkout-sdk-node",
-    "version": "1.0.29",
+    "version": "1.0.30",
     "description": "",
     "main": "./dist/index.js",
     "devDependencies": {

--- a/src/Checkout.js
+++ b/src/Checkout.js
@@ -78,6 +78,7 @@ export default class Checkout {
             host: determineHost(determineSecretKey(key), options),
             timeout: options && options.timeout ? options.timeout : DEFAULT_TIMEOUT,
             agent: options && options.agent ? options.agent : undefined,
+            headers: options && options.headers ? options.headers : {},
         };
 
         this.payments = new Payments(this.config);

--- a/src/api/apm-specific/baloto.js
+++ b/src/api/apm-specific/baloto.js
@@ -22,15 +22,11 @@ export default class Baloto {
      */
     async succeed(id) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/apms/baloto/payments/${id}/succeed`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/apms/baloto/payments/${id}/succeed`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/boleto.js
+++ b/src/api/apm-specific/boleto.js
@@ -22,15 +22,11 @@ export default class Boleto {
      */
     async succeed(id) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/apms/boleto/payments/${id}/succeed`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/apms/boleto/payments/${id}/succeed`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/fawry.js
+++ b/src/api/apm-specific/fawry.js
@@ -22,15 +22,11 @@ export default class Fawry {
      */
     async approve(reference) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'put',
-                    url: `${this.config.host}/fawry/payments/${reference}/approval`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'put',
+                url: `${this.config.host}/fawry/payments/${reference}/approval`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/giropay.js
+++ b/src/api/apm-specific/giropay.js
@@ -21,15 +21,11 @@ export default class Giropay {
      */
     async getEpsBanks() {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url: `${this.config.host}/giropay/eps/banks`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url: `${this.config.host}/giropay/eps/banks`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/ideal.js
+++ b/src/api/apm-specific/ideal.js
@@ -21,15 +21,11 @@ export default class Ideal {
      */
     async get() {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url: `${this.config.host}/ideal-external`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url: `${this.config.host}/ideal-external`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/klarna.js
+++ b/src/api/apm-specific/klarna.js
@@ -24,16 +24,12 @@ export default class Klarna {
             ? `${this.config.host}/klarna-external/credit-sessions`
             : `${this.config.host}/klarna/credit-sessions`;
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url,
-                    headers: { Authorization: this.config.sk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url,
+                headers: { Authorization: this.config.sk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/oxxo.js
+++ b/src/api/apm-specific/oxxo.js
@@ -22,15 +22,11 @@ export default class Oxxo {
      */
     async succeed(id) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/apms/oxxo/payments/${id}/succeed`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/apms/oxxo/payments/${id}/succeed`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/pagofacil.js
+++ b/src/api/apm-specific/pagofacil.js
@@ -22,15 +22,11 @@ export default class PagoFacil {
      */
     async succeed(id) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/apms/pagofacil/payments/${id}/succeed`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/apms/pagofacil/payments/${id}/succeed`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/rapipago.js
+++ b/src/api/apm-specific/rapipago.js
@@ -22,15 +22,11 @@ export default class Rapipago {
      */
     async succeed(id) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/apms/rapipago/payments/${id}/succeed`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/apms/rapipago/payments/${id}/succeed`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/apm-specific/sepa.js
+++ b/src/api/apm-specific/sepa.js
@@ -24,15 +24,11 @@ export default class Sepa {
             ? `${this.config.host}/sepa-external/mandates/${id}`
             : `${this.config.host}/sepa/mandates/${id}`;
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/customers/customers.js
+++ b/src/api/customers/customers.js
@@ -23,16 +23,12 @@ export default class Customers {
      */
     async update(id, body) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'patch',
-                    url: `${this.config.host}/customers/${id}`,
-                    headers: { Authorization: this.config.sk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'patch',
+                url: `${this.config.host}/customers/${id}`,
+                headers: { Authorization: this.config.sk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/disputes/disputes.js
+++ b/src/api/disputes/disputes.js
@@ -33,15 +33,11 @@ export default class Disputes {
                     .join('&');
                 url += `?${queryString}`;
             }
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/events/events.js
+++ b/src/api/events/events.js
@@ -27,15 +27,11 @@ export default class Events {
             if (version) {
                 url += `?version=${version}`;
             }
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/files/files.js
+++ b/src/api/files/files.js
@@ -41,11 +41,7 @@ export default class Files {
 
             const response = await http(
                 fetch,
-                {
-                    timeout: this.config.timeout,
-                    agent: this.config.agent,
-                    formData: true,
-                },
+                { ...this.config, formData: true },
                 {
                     method: 'post',
                     url: `${this.config.host}/files`,

--- a/src/api/hosted-payments/hosted-payments.js
+++ b/src/api/hosted-payments/hosted-payments.js
@@ -22,16 +22,12 @@ export default class HostedPayments {
      */
     async create(body) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/hosted-payments`,
-                    headers: { Authorization: this.config.sk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/hosted-payments`,
+                headers: { Authorization: this.config.sk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/instruments/instruments.js
+++ b/src/api/instruments/instruments.js
@@ -25,16 +25,12 @@ export default class Instruments {
     async create(body) {
         setInstrumentType(body);
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/instruments`,
-                    headers: { Authorization: this.config.sk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/instruments`,
+                headers: { Authorization: this.config.sk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/payments-links/payments-links.js
+++ b/src/api/payments-links/payments-links.js
@@ -22,16 +22,12 @@ export default class PaymentLinks {
      */
     async create(body) {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/payment-links `,
-                    headers: { Authorization: this.config.sk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/payment-links `,
+                headers: { Authorization: this.config.sk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/payments/payments.js
+++ b/src/api/payments/payments.js
@@ -90,16 +90,13 @@ export default class Payments {
             setSourceOrDestinationType(body);
             validatePayment(body);
 
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/payments`,
-                    headers: determineHeaders(this.config, idempotencyKey),
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/payments`,
+                headers: determineHeaders(this.config, idempotencyKey),
+                body,
+            });
+
             return addUtilityParams(await response.json);
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/reconciliation/reconciliation.js
+++ b/src/api/reconciliation/reconciliation.js
@@ -30,15 +30,11 @@ export default class Reconciliation {
                     .join('&');
                 url += `?${queryString}`;
             }
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url,
+                headers: { Authorization: this.config.sk },
+            });
             const res = await response.json;
 
             // In case there is a "next" page, inject it in the response body

--- a/src/api/sources/sources.js
+++ b/src/api/sources/sources.js
@@ -25,16 +25,12 @@ export default class Sources {
     async add(body) {
         setSourceType(body);
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/sources`,
-                    headers: { Authorization: this.config.sk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/sources`,
+                headers: { Authorization: this.config.sk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/tokens/tokens.js
+++ b/src/api/tokens/tokens.js
@@ -25,16 +25,12 @@ export default class Tokens {
     async request(body) {
         setTokenType(body);
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'post',
-                    url: `${this.config.host}/tokens`,
-                    headers: { Authorization: this.config.pk },
-                    body,
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'post',
+                url: `${this.config.host}/tokens`,
+                headers: { Authorization: this.config.pk },
+                body,
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/api/webhooks/webhooks.js
+++ b/src/api/webhooks/webhooks.js
@@ -22,15 +22,11 @@ export default class Webhooks {
      */
     async retrieveWebhooks() {
         try {
-            const response = await http(
-                fetch,
-                { timeout: this.config.timeout, agent: this.config.agent },
-                {
-                    method: 'get',
-                    url: `${this.config.host}/webhooks`,
-                    headers: { Authorization: this.config.sk },
-                }
-            );
+            const response = await http(fetch, this.config, {
+                method: 'get',
+                url: `${this.config.host}/webhooks`,
+                headers: { Authorization: this.config.sk },
+            });
             return await response.json;
         } catch (err) {
             const error = await determineError(err);

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -5,6 +5,7 @@ const pjson = require('../../package.json');
 
 const http = async (fetch, config, request) => {
     const headers = {
+        ...config.headers,
         ...request.headers,
         'Content-Type': config.csv ? 'text/csv' : 'application/json',
         'Cache-Control': 'no-cache',

--- a/test/errors/apiError.js
+++ b/test/errors/apiError.js
@@ -17,7 +17,9 @@ describe('Handling Errors', () => {
             .post('/tokens')
             .reply(mockErrorCode, mockErrorResponse);
 
-        const cko = new Checkout({ pk: PK });
+        const cko = new Checkout();
+        cko.config.pk = PK;
+
         let errorWasThrown = false;
 
         try {

--- a/test/http/additionalHeaders.js
+++ b/test/http/additionalHeaders.js
@@ -1,0 +1,76 @@
+import { Checkout } from '../../src/index';
+import { expect } from 'chai';
+import nock from 'nock';
+
+const PK = 'pk_test_4296fd52-efba-4a38-b6ce-cf0d93639d8a';
+
+describe('HTTP', () => {
+    // Nice feature of `reqheaders` is that the value can be a function returning a boolean. 
+    // Since we don't care about the actual value of the headers, returning true has the effect
+    // of matching if the header simply exists.
+    const mockHeadersMatcher = {
+        'additional-header-a': () => true,
+        'additional-Header-b': () => true,
+    };
+
+    const mockToken = {
+        type: 'card',
+        token: 'tok_pmjyslgaam4uzmvaiwqyhovvsy',
+        expires_on: '2020-01-30T15:08:33Z',
+        expiry_month: 6,
+        expiry_year: 2029
+    }
+
+    it('should be able to pass additional headers', async() => {
+        nock('https://api.sandbox.checkout.com', {
+            reqheaders: mockHeadersMatcher
+        })
+            .post('/tokens')
+            .reply(201, mockToken);
+
+        const cko = new Checkout(null, {
+            headers: {
+                'additional-header-a': 'valueA',
+                'additional-Header-b': 'valueB',
+            }
+        });
+        cko.config.pk = PK;
+
+        const token = await cko.tokens.request({
+            type: 'card',
+            number: '4242424242424242',
+            expiry_month: 6,
+            expiry_year: 2029,
+            cvv: '100'
+        });
+
+        expect(token).to.deep.equal(mockToken);
+    });
+
+    it('should not match a request when additional headers are not provided', async() => {
+        nock('https://api.sandbox.checkout.com', {
+            reqheaders: mockHeadersMatcher
+        })
+            .post('/tokens')
+            .reply(201, mockToken);
+
+        const cko = new Checkout();
+        cko.config.pk = PK;
+
+        let errorWasThrown = false;
+
+        try {
+            await cko.tokens.request({
+                type: 'card',
+                number: '4242424242424242',
+                expiry_month: 6,
+                expiry_year: 2029,
+                cvv: '100'
+            });
+        } catch(error) {
+            errorWasThrown = true;
+        }
+
+        expect(errorWasThrown).to.equal(true);
+    });
+});

--- a/types/dist/Checkout.d.ts
+++ b/types/dist/Checkout.d.ts
@@ -33,12 +33,14 @@ export type config = {
     pk: string;
     timeout: number;
     agent?: http.Agent;
+    headers?: Record<string, string>;
 };
 
 type options = {
     pk: string;
     timeout?: number;
     agent?: http.Agent;
+    headers?: Record<string, string>;
 };
 
 export default class Checkout {


### PR DESCRIPTION
### Updates

- ability to add additional headers (required to pass `CKO-Correlation-ID`)
- refactored to pass `config` as an object to all endpoint handlers
- added tests for additional headers
- bumped the version