### PR TITLE
Support access credentials on typescript types

### DIFF
--- a/types/dist/Checkout.d.ts
+++ b/types/dist/Checkout.d.ts
@@ -53,11 +53,21 @@ export type config = {
 };
 
 type options = {
-    pk: string;
+    host?: string;
     timeout?: number;
     agent?: http.Agent;
     headers?: Record<string, string>;
-};
+} & (staticKeyOptions | oauthOptions);
+
+type staticKeyOptions = {
+    pk: string;
+}
+
+type oauthOptions = {
+    client: string;
+    scope?: Array<string>,
+    environment ?: string;
+}
 
 export default class Checkout {
     payments: Payments;


### PR DESCRIPTION
The current types for Typescript's Checkout client constructor don't support using access credentials currently. 

[Js Checkout Client Constructor code.](https://github.com/checkout/checkout-sdk-node/blob/master/src/Checkout.js#L98) 