### PR TITLE
Mark unsupported APM clients as deprecated

### DIFF
--- a/src/api/apm-specific/baloto.js
+++ b/src/api/apm-specific/baloto.js
@@ -5,6 +5,7 @@ import { post } from '../../services/http';
 /**
  * Class dealing with the /apms/baloto endpoint
  *
+ * @deprecated - Since version 2.1.2 - Should use Payments client instead
  * @export
  * @class Baloto
  */
@@ -16,6 +17,7 @@ export default class Baloto {
     /**
      * Succeed a Baloto payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Baloto
      * @return {Promise<Object>} A promise to the Baloto response.
@@ -38,6 +40,7 @@ export default class Baloto {
     /**
      * Cancel Baloto payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Baloto
      * @return {Promise<Object>} A promise to the Baloto response.

--- a/src/api/apm-specific/boleto.js
+++ b/src/api/apm-specific/boleto.js
@@ -5,6 +5,7 @@ import { post } from '../../services/http';
 /**
  * Class dealing with the /apms/boleto endpoint
  *
+ * @deprecated - Since version 2.1.2 - Should use Payments client instead
  * @export
  * @class Boleto
  */
@@ -16,6 +17,7 @@ export default class Boleto {
     /**
      * Succeed a Boleto payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Boleto
      * @return {Promise<Object>} A promise to the Boleto response.
@@ -38,6 +40,7 @@ export default class Boleto {
     /**
      * Cancel Boleto payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Boleto
      * @return {Promise<Object>} A promise to the Boleto response.

--- a/src/api/apm-specific/fawry.js
+++ b/src/api/apm-specific/fawry.js
@@ -5,6 +5,8 @@ import { put } from '../../services/http';
 /**
  * Class dealing with the /fawry endpoint
  *
+ * @deprecated - Since version 2.1.2 - To be removed in future versions.
+ * Should use Payments client instead
  * @export
  * @class Fawry
  */
@@ -16,6 +18,7 @@ export default class Fawry {
     /**
      * Approve Fawry payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} reference Reference.
      * @memberof Fawry
      * @return {Promise<Object>} A promise to the Fawry response.
@@ -38,6 +41,7 @@ export default class Fawry {
     /**
      * Cancel Fawry payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} reference Reference.
      * @memberof Fawry
      * @return {Promise<Object>} A promise to the Fawry response.

--- a/src/api/apm-specific/giropay.js
+++ b/src/api/apm-specific/giropay.js
@@ -5,6 +5,7 @@ import { get } from '../../services/http';
 /**
  * Class dealing with the /giropay endpoint
  *
+ * @deprecated - Since version 2.1.2 - Should use Payments client instead
  * @export
  * @class Giropay
  */
@@ -16,6 +17,7 @@ export default class Giropay {
     /**
      * Get Giropay EPS banks
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @memberof Giropay
      * @return {Promise<Object>} A promise to the banks response.
      */
@@ -37,6 +39,7 @@ export default class Giropay {
     /**
      * Get Giropay banks
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @memberof Giropay
      * @return {Promise<Object>} A promise to the banks response.
      */

--- a/src/api/apm-specific/oxxo.js
+++ b/src/api/apm-specific/oxxo.js
@@ -5,6 +5,7 @@ import { post } from '../../services/http';
 /**
  * Class dealing with the /apms/oxxo endpoint
  *
+ * @deprecated - Since version 2.1.2 - Should use Payments client instead
  * @export
  * @class Oxxo
  */
@@ -16,6 +17,7 @@ export default class Oxxo {
     /**
      * Succeed a Oxxo payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Oxxo
      * @return {Promise<Object>} A promise to the Oxxo response.
@@ -38,6 +40,7 @@ export default class Oxxo {
     /**
      * Cancel Oxxo payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Oxxo
      * @return {Promise<Object>} A promise to the Oxxo response.

--- a/src/api/apm-specific/pagofacil.js
+++ b/src/api/apm-specific/pagofacil.js
@@ -5,6 +5,7 @@ import { post } from '../../services/http';
 /**
  * Class dealing with the /apms/pagofacil endpoint
  *
+ * @deprecated - Since version 2.1.2 - Should use Payments client instead
  * @export
  * @class PagoFacil
  */
@@ -16,6 +17,7 @@ export default class PagoFacil {
     /**
      * Succeed a PagoFacil payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof PagoFacil
      * @return {Promise<Object>} A promise to the PagoFacil response.
@@ -38,6 +40,7 @@ export default class PagoFacil {
     /**
      * Cancel PagoFacil payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof PagoFacil
      * @return {Promise<Object>} A promise to the PagoFacil response.

--- a/src/api/apm-specific/rapipago.js
+++ b/src/api/apm-specific/rapipago.js
@@ -5,6 +5,7 @@ import { post } from '../../services/http';
 /**
  * Class dealing with the /apms/rapipago endpoint
  *
+ * @deprecated - Since version 2.1.2 - Should use Payments client instead
  * @export
  * @class Rapipago
  */
@@ -16,6 +17,7 @@ export default class Rapipago {
     /**
      * Succeed a Rapipago payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Rapipago
      * @return {Promise<Object>} A promise to the Rapipago response.
@@ -38,6 +40,7 @@ export default class Rapipago {
     /**
      * Cancel Rapipago payment
      *
+     * @deprecated - Since version 2.1.2 - Should use Payments client instead
      * @param {string} id Payment id.
      * @memberof Rapipago
      * @return {Promise<Object>} A promise to the Rapipago response.


### PR DESCRIPTION
Adds deprecated annotation to the following APM clients:
* Baloto
* Boleto
* Fawry
* Giropay
* Oxxo
* Pago Facil
* Rapi Pago