### PR TITLE
Add support for deprecated Payment Instrument Platform

### DIFF
--- a/src/api/platforms/platforms.js
+++ b/src/api/platforms/platforms.js
@@ -174,6 +174,31 @@ export default class Platforms {
     /**
      * Update a session by providing information about the environment.
      *
+     * @deprecated Use the payment instrument operations at /payment-instruments instead.
+     * @memberof Platforms
+     * @param {string} id Sub-entity id.
+     * @param {Object} body Platforms request body.
+     * @return {Promise<Object>} A promise to the Platforms response.
+     */
+    async createPaymentInstrument(id, body) {
+        try {
+            const response = await post(
+                fetch,
+                `${this.config.host}/accounts/entities/${id}/instruments`,
+                this.config,
+                this.config.sk,
+                body
+            );
+            return await response.json;
+        } catch (err) {
+            const error = await determineError(err);
+            throw error;
+        }
+    }
+
+    /**
+     * Update a session by providing information about the environment.
+     *
      * @memberof Platforms
      * @param {string} id Sub-entity id.
      * @param {Object} body Platforms request body.


### PR DESCRIPTION
Added support for deprecated payment instrument method

## API Reference
https://api-reference.checkout.com/#operation/addAPaymentInstrument