### PR TITLE
Missing types in Payment Type. Payment Request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "checkout-sdk-node",
-    "version": "2.2.0",
+    "version": "2.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "checkout-sdk-node",
-            "version": "2.2.0",
+            "version": "2.2.2",
             "license": "MIT",
             "dependencies": {
                 "form-data": "^4.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,8 @@ export const PAYMENT_TYPES = {
     regular: 'Regular',
     recurring: 'Recurring',
     moto: 'MOTO',
+    installment: 'Installment',
+    unscheduled: 'Unscheduled'
 };
 export const CURRENCIES = {
     ALL: 'ALL',


### PR DESCRIPTION
## Missing payment types in payment request
- Installment
- Unscheduled

## Issue related
[Missing types in Payment Type. Payment Request #348
](https://github.com/checkout/checkout-sdk-node/issues/348)

## API Reference
https://api-reference.checkout.com/#operation/requestAPaymentOrPayout!path=0/payment_type&t=request