### PR TITLE
Release 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "checkout-sdk-node",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "",
     "main": "./dist/index.js",
     "devDependencies": {


### PR DESCRIPTION
- Missing payment types in payment request, `Installment` and `Unscheduled`