### PR TITLE
feat: add Forward API class with request forwarding functionality

### DIFF
--- a/src/Checkout.js
+++ b/src/Checkout.js
@@ -194,5 +194,6 @@ export default class Checkout {
         this.issuing = new ENDPOINTS.Issuing(this.config);
         this.paymentContexts = new ENDPOINTS.PaymentContexts(this.config);
         this.paymentSessions = new ENDPOINTS.PaymentSessions(this.config);
+        this.forward = new ENDPOINTS.Forward(this.config);
     }
 }

--- a/src/api/forward/forward.js
+++ b/src/api/forward/forward.js
@@ -1,0 +1,62 @@
+import { determineError } from '../../services/errors';
+import { get, post } from '../../services/http';
+
+/**
+ * Class dealing with the /forward endpoint
+ *
+ * @export
+ * @class Forward
+ */
+export default class Forward {
+    constructor(config) {
+        this.config = config;
+    }
+
+    /**
+     * Beta
+     * Forwards an API request to a third-party endpoint.
+     * For example, you can forward payment credentials you've stored in our Vault to a third-party payment processor.
+     *
+     * Forward an API request
+     * @param {Object} body Forward request body
+     * @return {Promise<Object>} A promise to the forward response
+     */
+    async forwardRequest(body) {
+        try {
+            const response = await post(
+                this.config.httpClient,
+                `${this.config.host}/forward`,
+                this.config,
+                this.config.sk,
+                body
+            );
+            return await response.json;
+        } catch (err) {
+            const error = await determineError(err);
+            throw error;
+        }
+    }
+
+    /**
+     * Retrieve the details of a successfully forwarded API request.
+     * The details can be retrieved for up to 14 days after the request was initiated.
+     *
+     * Get forward request
+     * @param {string} id The unique identifier of the forward request
+     * @return {Promise<Object>} A promise to the forward request details
+     */
+    async get(id) {
+        try {
+            const response = await get(
+                this.config.httpClient,
+                `${this.config.host}/forward/${id}`,
+                this.config,
+                this.config.sk
+            );
+            return await response.json;
+        } catch (err) {
+            const error = await determineError(err);
+            throw error;
+        }
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -36,5 +36,6 @@ export { default as Financial } from './api/financial/financial';
 export { default as Issuing } from './api/issuing/issuing';
 export { default as PaymentContexts } from './api/payment-contexts/payment-contexts';
 export { default as PaymentSessions } from './api/payment-sessions/payment-sessions';
+export { default as Forward } from './api/forward/forward';
 export { default as Checkout } from './Checkout';
 export { default } from './Checkout';

--- a/test/forward/forward-it.js
+++ b/test/forward/forward-it.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import Checkout from '../../src/Checkout.js';
+import { NotFoundError } from '../../src/services/errors.js';
+
+const cko = new Checkout(process.env.CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET, {
+    client: process.env.CHECKOUT_DEFAULT_OAUTH_CLIENT_ID,
+    scope: ['forward'],
+    environment: 'sandbox',
+});
+
+describe('Integration::Forward', () => {
+    it.skip('should forward an API request', async () => {
+        const body = {
+            source: {
+                id: 'src_v5rgkf3gdtpuzjqesyxmyodnya',
+                type: 'id'
+            },
+            reference: 'ORD-5023-4E89',
+            processing_channel_id: 'pc_azsiyswl7bwe2ynjzujy7lcjca',
+            network_token: {
+                enabled: true,
+                request_cryptogram: false
+            },
+            destination_request: {
+                url: 'https://example.com/payments',
+                method: 'POST',
+                headers: {
+                    encrypted: '<JWE encrypted JSON object with string values>',
+                    raw: {
+                        'Idempotency-Key': 'xe4fad12367dfgrds',
+                        'Content-Type': 'application/json'
+                    }
+                },
+                body: '{"amount": 1000, "currency": "USD", "reference": "some_reference", "source": {"type": "card", "number": "{{card_number}}", "expiry_month": "{{card_expiry_month}}", "expiry_year": "{{card_expiry_year_yyyy}}", "name": "Ali Farid"}, "payment_type": "Regular", "authorization_type": "Final", "capture": true, "processing_channel_id": "pc_xxxxxxxxxxx", "risk": {"enabled": false}, "merchant_initiated": true}',
+                signature: {
+                    type: 'dlocal',
+                    dlocal_parameters: {
+                        secret_key: '9f439fe1a9f96e67b047d3c1a28c33a2e'
+                    }
+                }
+            }
+        };
+        const result = await cko.forward.forwardRequest(body);
+        expect(result).to.have.property('request_id');
+        expect(result).to.have.property('destination_response');
+    });
+
+    it.skip('should get a forward request', async () => {
+        const requestId = 'fwd_01HK153X00VZ1K15Z3HYC0QGPN';
+        const result = await cko.forward.get(requestId);
+        expect(result).to.have.property('request_id');
+        expect(result).to.have.property('reference');
+        expect(result).to.have.property('entity_id');
+        expect(result).to.have.property('destination_request');
+        expect(result).to.have.property('destination_response');
+        expect(result).to.have.property('created_on');
+    });
+
+    it('should throw an error for not found (404)', async () => {
+        const invalidRequestId = 'fwd_invalid_id';
+        try {
+            await cko.forward.get(invalidRequestId);
+            throw new Error('Should have thrown 404 error');
+        } catch (err) {
+            expect(err).to.be.instanceOf(NotFoundError);
+            expect(err.http_code).to.equal(404);
+        }
+    });
+});

--- a/test/forward/forward-unit.js
+++ b/test/forward/forward-unit.js
@@ -1,0 +1,262 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import Checkout from '../../src/Checkout.js';
+import { AuthenticationError, NotFoundError, ValidationError } from '../../src/services/errors.js';
+
+const SK = 'sk_test_0b9b5db6-f223-49d0-b68f-f6643dd4f808';
+
+describe('Unit::Forward', () => {
+    it('should forward an API request', async () => {
+        nock('https://api.sandbox.checkout.com')
+            .post('/forward', {
+                source: {
+                    id: 'src_v5rgkf3gdtpuzjqesyxmyodnya',
+                    type: 'id'
+                },
+                reference: 'ORD-5023-4E89',
+                processing_channel_id: 'pc_azsiyswl7bwe2ynjzujy7lcjca',
+                network_token: {
+                    enabled: true,
+                    request_cryptogram: false
+                },
+                destination_request: {
+                    url: 'https://example.com/payments',
+                    method: 'POST',
+                    headers: {
+                        encrypted: '<JWE encrypted JSON object with string values>',
+                        raw: {
+                            'Idempotency-Key': 'xe4fad12367dfgrds',
+                            'Content-Type': 'application/json'
+                        }
+                    },
+                    body: '{"amount": 1000, "currency": "USD", "reference": "some_reference", "source": {"type": "card", "number": "{{card_number}}", "expiry_month": "{{card_expiry_month}}", "expiry_year": "{{card_expiry_year_yyyy}}", "name": "Ali Farid"}, "payment_type": "Regular", "authorization_type": "Final", "capture": true, "processing_channel_id": "pc_xxxxxxxxxxx", "risk": {"enabled": false}, "merchant_initiated": true}',
+                    signature: {
+                        type: 'dlocal',
+                        dlocal_parameters: {
+                            secret_key: '9f439fe1a9f96e67b047d3c1a28c33a2e'
+                        }
+                    }
+                }
+            })
+            .reply(200, {
+                request_id: 'fwd_01HK153X00VZ1K15Z3HYC0QGPN',
+                destination_response: {
+                    status: 201,
+                    headers: {
+                        'Cko-Request-Id': [
+                            '5fa7ee8c-f82d-4440-a6dc-e8c859b03235'
+                        ],
+                        'Content-Type': [
+                            'application/json'
+                        ]
+                    },
+                    body: '{"id": "pay_mbabizu24mvu3mela5njyhpit4", "action_id": "act_mbabizu24mvu3mela5njyhpit4", "amount": 6540, "currency": "USD", "approved": true, "status": "Authorized", "auth_code": "770687", "response_code": "10000", "response_summary": "Approved", "_links": {"self": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"}, "action": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"}, "void": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"}, "capture": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"}}}'
+                }
+            });
+
+        const cko = new Checkout(SK);
+        const result = await cko.forward.forwardRequest({
+            source: {
+                id: 'src_v5rgkf3gdtpuzjqesyxmyodnya',
+                type: 'id'
+            },
+            reference: 'ORD-5023-4E89',
+            processing_channel_id: 'pc_azsiyswl7bwe2ynjzujy7lcjca',
+            network_token: {
+                enabled: true,
+                request_cryptogram: false
+            },
+            destination_request: {
+                url: 'https://example.com/payments',
+                method: 'POST',
+                headers: {
+                    encrypted: '<JWE encrypted JSON object with string values>',
+                    raw: {
+                        'Idempotency-Key': 'xe4fad12367dfgrds',
+                        'Content-Type': 'application/json'
+                    }
+                },
+                body: '{"amount": 1000, "currency": "USD", "reference": "some_reference", "source": {"type": "card", "number": "{{card_number}}", "expiry_month": "{{card_expiry_month}}", "expiry_year": "{{card_expiry_year_yyyy}}", "name": "Ali Farid"}, "payment_type": "Regular", "authorization_type": "Final", "capture": true, "processing_channel_id": "pc_xxxxxxxxxxx", "risk": {"enabled": false}, "merchant_initiated": true}',
+                signature: {
+                    type: 'dlocal',
+                    dlocal_parameters: {
+                        secret_key: '9f439fe1a9f96e67b047d3c1a28c33a2e'
+                    }
+                }
+            }
+        });
+        expect(result).to.deep.equal({
+            request_id: 'fwd_01HK153X00VZ1K15Z3HYC0QGPN',
+            destination_response: {
+                status: 201,
+                headers: {
+                    'Cko-Request-Id': [
+                        '5fa7ee8c-f82d-4440-a6dc-e8c859b03235'
+                    ],
+                    'Content-Type': [
+                        'application/json'
+                    ]
+                },
+                body: '{"id": "pay_mbabizu24mvu3mela5njyhpit4", "action_id": "act_mbabizu24mvu3mela5njyhpit4", "amount": 6540, "currency": "USD", "approved": true, "status": "Authorized", "auth_code": "770687", "response_code": "10000", "response_summary": "Approved", "_links": {"self": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"}, "action": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"}, "void": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"}, "capture": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"}}}'
+            }
+        });
+    });
+
+    it('should get a forward request', async () => {
+        nock('https://api.sandbox.checkout.com')
+            .get('/forward/fwd_01HK153X00VZ1K15Z3HYC0QGPN')
+            .reply(200, {
+                request_id: 'fwd_01HK153X00VZ1K15Z3HYC0QGPN',
+                reference: 'ORD-5023-4E89',
+                entity_id: 'ent_lp6h57qskk6ubewfk3pq4f2c2y',
+                destination_request: {
+                    url: 'https://example.com/payments',
+                    method: 'POST',
+                    headers: {
+                        Authorization: '***redacted***',
+                        'Idempotency-Key': 'xe4fad12367dfgrds',
+                        'Content-Type': 'application/json'
+                    },
+                    body: '{"amount": 1000, "currency": "USD", "reference": "some_reference", "source": {"type": "card", "number": "{{card_number}}", "expiry_month": "{{card_expiry_month}}", "expiry_year": "{{card_expiry_year_yyyy}}", "name": "Ali Farid"}, "payment_type": "Regular", "authorization_type": "Final", "capture": true, "processing_channel_id": "pc_xxxxxxxxxxx", "risk": {"enabled": false}, "merchant_initiated": true}'
+                },
+                destination_response: {
+                    status: 201,
+                    headers: {
+                        'Cko-Request-Id': [
+                            '5fa7ee8c-f82d-4440-a6dc-e8c859b03235'
+                        ],
+                        'Content-Type': [
+                            'application/json'
+                        ]
+                    },
+                    body: '{"id": "pay_mbabizu24mvu3mela5njyhpit4", "action_id": "act_mbabizu24mvu3mela5njyhpit4", "amount": 6540, "currency": "USD", "approved": true, "status": "Authorized", "auth_code": "770687", "response_code": "10000", "response_summary": "Approved", "_links": {"self": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"}, "action": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"}, "void": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"}, "capture": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"}}}'
+                },
+                created_on: '2024-01-02T15:04:05+00:00'
+            });
+
+        const cko = new Checkout(SK);
+        const result = await cko.forward.get('fwd_01HK153X00VZ1K15Z3HYC0QGPN');
+        expect(result).to.deep.equal({
+            request_id: 'fwd_01HK153X00VZ1K15Z3HYC0QGPN',
+            reference: 'ORD-5023-4E89',
+            entity_id: 'ent_lp6h57qskk6ubewfk3pq4f2c2y',
+            destination_request: {
+                url: 'https://example.com/payments',
+                method: 'POST',
+                headers: {
+                    Authorization: '***redacted***',
+                    'Idempotency-Key': 'xe4fad12367dfgrds',
+                    'Content-Type': 'application/json'
+                },
+                body: '{"amount": 1000, "currency": "USD", "reference": "some_reference", "source": {"type": "card", "number": "{{card_number}}", "expiry_month": "{{card_expiry_month}}", "expiry_year": "{{card_expiry_year_yyyy}}", "name": "Ali Farid"}, "payment_type": "Regular", "authorization_type": "Final", "capture": true, "processing_channel_id": "pc_xxxxxxxxxxx", "risk": {"enabled": false}, "merchant_initiated": true}'
+            },
+            destination_response: {
+                status: 201,
+                headers: {
+                    'Cko-Request-Id': [
+                        '5fa7ee8c-f82d-4440-a6dc-e8c859b03235'
+                    ],
+                    'Content-Type': [
+                        'application/json'
+                    ]
+                },
+                body: '{"id": "pay_mbabizu24mvu3mela5njyhpit4", "action_id": "act_mbabizu24mvu3mela5njyhpit4", "amount": 6540, "currency": "USD", "approved": true, "status": "Authorized", "auth_code": "770687", "response_code": "10000", "response_summary": "Approved", "_links": {"self": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"}, "action": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"}, "void": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"}, "capture": {"href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"}}}'
+            },
+            created_on: '2024-01-02T15:04:05+00:00'
+        });
+    });
+
+    it('should throw an error for unauthorized (401)', async () => {
+        nock('https://api.sandbox.checkout.com')
+            .post('/forward')
+            .reply(401, {});
+
+        const cko = new Checkout('sk_test_invalid');
+        try {
+            await cko.forward.forwardRequest({
+                source: { id: 'src_v5rgkf3gdtpuzjqesyxmyodnya', type: 'id' },
+                reference: 'ORD-5023-4E89',
+                processing_channel_id: 'pc_azsiyswl7bwe2ynjzujy7lcjca',
+                network_token: { enabled: true, request_cryptogram: false },
+                destination_request: {
+                    url: 'https://example.com/payments',
+                    method: 'POST',
+                    headers: {
+                        encrypted: '<JWE encrypted JSON object with string values>',
+                        raw: {
+                            'Idempotency-Key': 'xe4fad12367dfgrds',
+                            'Content-Type': 'application/json'
+                        }
+                    },
+                    body: '{"amount": 1000, "currency": "USD"}',
+                    signature: { type: 'dlocal', dlocal_parameters: { secret_key: 'invalid' } }
+                }
+            });
+            throw new Error('Should have thrown 401 error');
+        } catch (err) {
+            expect(err).to.be.instanceOf(AuthenticationError);
+            expect(err.http_code).to.equal(401);
+        }
+    });
+
+    it('should throw an error for validation error (422)', async () => {
+        nock('https://api.sandbox.checkout.com')
+            .post('/forward')
+            .reply(422, {
+                request_id: 'fwd_01HK153X00VZ1K15Z3HYC0QGPN:00000001',
+                error_type: 'request_invalid',
+                error_codes: ['processing_channel_id_required'],
+                errors: {
+                    processing_channel_id: [
+                        'The processing_channel_id field is required'
+                    ]
+                }
+            });
+
+        const cko = new Checkout(SK);
+        try {
+            await cko.forward.forwardRequest({
+                source: { id: 'src_v5rgkf3gdtpuzjqesyxmyodnya', type: 'id' },
+                reference: 'ORD-5023-4E89',
+                processing_channel_id: 'pc_azsiyswl7bwe2ynjzujy7lcjca',
+                network_token: { enabled: true, request_cryptogram: false },
+                destination_request: {
+                    url: 'invalid-url',
+                    method: 'POST',
+                    headers: {
+                        encrypted: '<JWE encrypted JSON object with string values>',
+                        raw: {
+                            'Idempotency-Key': 'xe4fad12367dfgrds',
+                            'Content-Type': 'application/json'
+                        }
+                    },
+                    body: '{"amount": 1000, "currency": "USD"}',
+                    signature: { type: 'dlocal', dlocal_parameters: { secret_key: 'invalid' } }
+                }
+            });
+            throw new Error('Should have thrown 422 error');
+        } catch (err) {
+            expect(err).to.be.instanceOf(ValidationError);
+            expect(err.http_code).to.equal(422);
+        }
+    });
+
+    it('should throw an error for not found (404)', async () => {
+        nock('https://api.sandbox.checkout.com')
+            .get('/forward/fwd_invalid_id')
+            .reply(404, {
+                error_type: 'not_found',
+                error_codes: ['forward_request_not_found'],
+                message: 'The forward request was not found.'
+            });
+
+        const cko = new Checkout(SK);
+        try {
+            await cko.forward.get('fwd_invalid_id');
+            throw new Error('Should have thrown 404 error');
+        } catch (err) {
+            expect(err).to.be.instanceOf(NotFoundError);
+            expect(err.http_code).to.equal(404);
+        }
+    });
+});

--- a/types/dist/Checkout.d.ts
+++ b/types/dist/Checkout.d.ts
@@ -15,6 +15,7 @@ import {
     Files,
     Financial,
     Forex,
+    Forward,
     Giropay,
     HostedPayments,
     Ideal,
@@ -114,6 +115,7 @@ export default class Checkout {
     issuing: Issuing;
     paymentContexts: PaymentContexts;
     paymentSessions: PaymentSessions;
+    forward: Forward;
     config: config;
 
     constructor(key?: string, options?: options);

--- a/types/dist/api/forward/forward.d.ts
+++ b/types/dist/api/forward/forward.d.ts
@@ -1,0 +1,8 @@
+import { config } from '../../Checkout';
+
+export default class Forward {
+    constructor(config: config);
+    
+    forwardRequest(body: object): Promise<object>;
+    get(id: string): Promise<object>;
+}

--- a/types/dist/index.d.ts
+++ b/types/dist/index.d.ts
@@ -35,5 +35,6 @@ export { default as Financial } from './api/financial/financial';
 export { default as Issuing } from './api/issuing/issuing';
 export { default as PaymentContexts } from './api/payment-contexts/payment-contexts';
 export { default as PaymentSessions } from './api/payment-sessions/payment-sessions';
+export { default as Forward } from './api/forward/forward';
 export { default as Checkout } from './Checkout';
 export { default } from './Checkout';


### PR DESCRIPTION
This pull request introduces a new `Forward` API endpoint to the `Checkout` library, enabling users to forward API requests to third-party endpoints and retrieve details of the forwarded requests. The changes include adding the `Forward` class, integrating it into the `Checkout` class, and providing both unit and integration tests for the new functionality.

### New Feature: `Forward` API Endpoint

* **`Forward` Class Implementation**: Added a new `Forward` class in `src/api/forward/forward.js` to handle the `/forward` API endpoint. This includes methods for forwarding API requests (`forwardRequest`) and retrieving details of forwarded requests (`get`). Error handling is implemented using the `determineError` utility.

* **Integration with `Checkout` Class**: Integrated the `Forward` class into the `Checkout` class in `src/Checkout.js` by adding it as a property (`this.forward`) initialized with the configuration.

* **Export in Library Index**: Exported the `Forward` class in `src/index.js` to make it accessible as part of the library's public API.

### Testing Enhancements

* **Integration Tests**: Added integration tests in `test/forward/forward-it.js` to validate the functionality of the `Forward` API. Tests include forwarding a request, retrieving request details, and handling a 404 "not found" error.

* **Unit Tests**: Added unit tests in `test/forward/forward-unit.js` using `nock` to mock API responses. Tests cover successful requests, error scenarios (401 unauthorized, 404 not found, 422 validation error), and response validation.