### PR TITLE
Release 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkout-sdk-node",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkout-sdk-node",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-sdk-node",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Checkout NodeJS SDK API",
   "type": "module",
   "engines": {


### PR DESCRIPTION
- fix: update webhookParsingMiddleware to use Function type for next parameter (#413)
- chore: remove unnecessary entries from .npmignore
- chore: add nodemon as a dev dependency and update @mswjs/interceptors version