### PR TITLE
fix: set modules option to false in Babel preset-env configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       [
         "@babel/preset-env",
         {
+          "modules": false,
           "targets": {
             "node": 18
           }


### PR DESCRIPTION
This pull request makes a small configuration update to the Babel setup in `package.json`. The change disables Babel's module transformation by setting `"modules": false`, which is useful when the bundler or runtime handles ES modules natively.

- Babel configuration: Set `"modules": false` in the `@babel/preset-env` options to prevent Babel from transforming ES modules.