### PR TITLE
Issue 418 - files.upload failure

### DIFF
--- a/src/services/http.js
+++ b/src/services/http.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { Writable } from 'stream';
 import {
     API_VERSION_HEADER,
     ETAG_HEADER,
@@ -68,6 +69,8 @@ function getRequestHeaders(config, request, authHeader, idempotencyKey) {
 
     if (!config.formData) {
         headers['Content-Type'] = config.csv ? 'text/csv' : 'application/json';
+    } else if (request && typeof request.getHeaders === 'function') {
+        headers = { ...headers, ...request.getHeaders() };
     }
 
     if (idempotencyKey !== undefined) {
@@ -75,6 +78,22 @@ function getRequestHeaders(config, request, authHeader, idempotencyKey) {
     }
 
     return headers;
+}
+
+function formDataToBuffer(form) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        const sink = new Writable({
+            write(chunk, _encoding, callback) {
+                chunks.push(chunk);
+                callback();
+            },
+        });
+        sink.on('finish', () => resolve(Buffer.concat(chunks)));
+        sink.on('error', reject);
+        form.on('error', reject);
+        form.pipe(sink);
+    });
 }
 
 function getResponseHeaders(response) {
@@ -277,9 +296,15 @@ const httpRequest = async (httpClient, method, path, config, auth, request, idem
             }
 
         default:
+            let body;
+            if (config.formData && request && typeof request.getHeaders === 'function') {
+                body = await formDataToBuffer(request);
+            } else {
+                body = config.formData ? request : JSON.stringify(request);
+            }
             const fetchOptions = {
                 method,
-                body: config.formData ? request : JSON.stringify(request),
+                body,
                 headers,
             };
             if (typeof config.agent !== 'undefined') {

--- a/test/files/files.js
+++ b/test/files/files.js
@@ -124,11 +124,15 @@ describe('Files', () => {
 
     it('should upload file with different purpose values', async () => {
         const purposes = ['additional_document', 'bank_verification', 'identity_verification'];
-        
+
         for (const purpose of purposes) {
-            // Simple mock without body inspection since FormData can't be easily inspected
+            let capturedBody = null;
             nock('https://123456789.api.sandbox.checkout.com')
-                .post('/files')
+                .matchHeader('content-type', /^multipart\/form-data; boundary=/)
+                .post('/files', (body) => {
+                    capturedBody = body;
+                    return true;
+                })
                 .reply(200, {
                     id: 'file_test_' + purpose,
                     _links: {
@@ -144,42 +148,72 @@ describe('Files', () => {
                 path: fs.createReadStream('./test/files/evidence.jpg'),
                 purpose: purpose,
             });
-            
+
             expect(file.id).to.equal('file_test_' + purpose);
+            expect(capturedBody).to.match(
+                new RegExp(`name="purpose"\\r\\n\\r\\n${purpose}\\r\\n`),
+                `purpose field "${purpose}" must appear in multipart body`
+            );
+            expect(capturedBody).to.match(
+                /name="file"; filename=/,
+                'file field must appear in multipart body'
+            );
         }
     }).timeout(120000);
 
-    it('should include purpose parameter in request body', async () => {
-        let capturedRequest = null;
-        
-        // Mock to capture the request details
+    // Regression test for https://github.com/checkout/checkout-sdk-node/issues/418
+    // The bug: native fetch string-coerced the form-data v4 instance, sending the literal
+    // text "[object FormData]" as a text/plain body. The API never saw the purpose field
+    // and returned purpose_required / purpose_invalid.
+    it('should send a properly framed multipart body with purpose in form-data (regression #418)', async () => {
+        let capturedHeaders = null;
+        let capturedBody = null;
+
         nock('https://123456789.api.sandbox.checkout.com')
-            .post('/files')
-            .reply(function() {
-                // Capture the request body for verification
-                capturedRequest = this.req;
-                return [200, {
-                    id: 'file_test_purpose_check',
-                    _links: {
-                        self: {
-                            href: 'https://123456789.api.sandbox.checkout.com/files/file_test_purpose_check',
+            .post('/files', (body) => {
+                capturedBody = body;
+                return true;
+            })
+            .reply(function () {
+                capturedHeaders = this.req.headers;
+                return [
+                    201,
+                    {
+                        id: 'file_regression_418',
+                        _links: {
+                            self: {
+                                href: 'https://123456789.api.sandbox.checkout.com/files/file_regression_418',
+                            },
                         },
                     },
-                }];
+                ];
             });
 
         const cko = new Checkout(SK, { subdomain: '123456789' });
-
         await cko.files.upload({
             path: fs.createReadStream('./test/files/evidence.jpg'),
-            purpose: 'identity_verification',
+            purpose: 'dispute_evidence',
         });
 
-        // Verify the request was made
-        expect(capturedRequest).to.not.be.null;
-        
-        // Note: We can't easily inspect FormData content in tests, but we've verified 
-        // the code path includes the purpose parameter in the upload implementation
+        const contentType =
+            capturedHeaders && (capturedHeaders['content-type'] || capturedHeaders['Content-Type']);
+        expect(contentType).to.match(
+            /^multipart\/form-data; boundary=/,
+            'Content-Type must be multipart/form-data with a boundary'
+        );
+
+        expect(capturedBody).to.not.include(
+            '[object FormData]',
+            'body must not contain the string "[object FormData]" — that means the form-data instance was string-coerced instead of serialized'
+        );
+        expect(capturedBody).to.match(
+            /name="purpose"\r\n\r\ndispute_evidence\r\n/,
+            'purpose field must be present in the multipart body'
+        );
+        expect(capturedBody).to.match(
+            /name="file"; filename=/,
+            'file field must be present in the multipart body'
+        );
     }).timeout(120000);
 
     it('should throw ValidationError when purpose is missing', async () => {

--- a/test/files/files.js
+++ b/test/files/files.js
@@ -149,12 +149,15 @@ describe('Files', () => {
                 purpose: purpose,
             });
 
+            // nock represents binary (Buffer) request bodies as a hex-encoded string
+            // when handed to the matcher callback. Decode before matching.
+            const bodyText = Buffer.from(capturedBody, 'hex').toString('utf8');
             expect(file.id).to.equal('file_test_' + purpose);
-            expect(capturedBody).to.match(
+            expect(bodyText).to.match(
                 new RegExp(`name="purpose"\\r\\n\\r\\n${purpose}\\r\\n`),
                 `purpose field "${purpose}" must appear in multipart body`
             );
-            expect(capturedBody).to.match(
+            expect(bodyText).to.match(
                 /name="file"; filename=/,
                 'file field must appear in multipart body'
             );
@@ -202,15 +205,17 @@ describe('Files', () => {
             'Content-Type must be multipart/form-data with a boundary'
         );
 
-        expect(capturedBody).to.not.include(
+        // nock hex-encodes binary (Buffer) request bodies in the matcher callback.
+        const bodyText = Buffer.from(capturedBody, 'hex').toString('utf8');
+        expect(bodyText).to.not.include(
             '[object FormData]',
             'body must not contain the string "[object FormData]" — that means the form-data instance was string-coerced instead of serialized'
         );
-        expect(capturedBody).to.match(
+        expect(bodyText).to.match(
             /name="purpose"\r\n\r\ndispute_evidence\r\n/,
             'purpose field must be present in the multipart body'
         );
-        expect(capturedBody).to.match(
+        expect(bodyText).to.match(
             /name="file"; filename=/,
             'file field must be present in the multipart body'
         );


### PR DESCRIPTION
This pull request improves multipart form-data handling in HTTP requests, specifically ensuring that `FormData` is properly serialized and sent in API calls. The changes fix a bug where the form-data instance was previously string-coerced (resulting in an invalid request body), and add comprehensive regression tests to prevent this issue from recurring.

**HTTP request handling improvements:**

* Added a `formDataToBuffer` utility to serialize `FormData` streams into a buffer, ensuring multipart bodies are transmitted correctly in HTTP requests.
* Updated the HTTP request logic to use the new buffer serialization for `FormData`, preventing accidental string coercion and ensuring the correct `Content-Type` and body format.
* Enhanced header generation to merge headers from `FormData` instances when present, ensuring the multipart boundary is set correctly.
* Imported Node's `Writable` stream to support the new buffer serialization logic.

**Testing and regression coverage:**

* Improved and expanded tests in `test/files/files.js` to verify that multipart requests include the correct fields and headers, and added a regression test for issue #418 to ensure the bug does not reoccur. [[1]](diffhunk://#diff-08daf901d12978c35b6c66ee0e4774c49355251fe5a479d83a21b6dc3fe8d3ebL129-R135) [[2]](diffhunk://#diff-08daf901d12978c35b6c66ee0e4774c49355251fe5a479d83a21b6dc3fe8d3ebR153-R216)