### PR TITLE
fix: correct identity-verification base URL and tighten subdomain regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ out
 docs/
 
 swagger.*
+.claude/
+CLAUDE.md

--- a/src/EnvironmentSubdomain.js
+++ b/src/EnvironmentSubdomain.js
@@ -61,7 +61,7 @@ export default class EnvironmentSubdomain {
         if (!subdomain || typeof subdomain !== 'string') {
             return false;
         }
-        const pattern = /^[0-9a-z]+$/;
+        const pattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
         return pattern.test(subdomain);
     }
 

--- a/src/EnvironmentSubdomain.js
+++ b/src/EnvironmentSubdomain.js
@@ -61,7 +61,7 @@ export default class EnvironmentSubdomain {
         if (!subdomain || typeof subdomain !== 'string') {
             return false;
         }
-        const pattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+        const pattern = /^(?:pl-)?[a-z0-9]+$/;
         return pattern.test(subdomain);
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -16,8 +16,8 @@ export const FORWARD_LIVE_URL = 'https://forward.checkout.com/forward';
 export const BALANCES_SANDBOX_URL = 'https://balances.sandbox.checkout.com/balances';
 export const BALANCES_LIVE_URL = 'https://balances.checkout.com/balances';
 
-export const IDENTITY_VERIFICATION_SANDBOX_URL = 'https://identity-verification.api.sandbox.checkout.com';
-export const IDENTITY_VERIFICATION_LIVE_URL = 'https://identity-verification.api.checkout.com';
+export const IDENTITY_VERIFICATION_SANDBOX_URL = 'https://identity-verification.sandbox.checkout.com';
+export const IDENTITY_VERIFICATION_LIVE_URL = 'https://identity-verification.checkout.com';
 
 export const REQUEST_ID_HEADER = 'cko-request-id';
 export const API_VERSION_HEADER = 'cko-version';

--- a/test/environment-subdomain/environment-subdomain.js
+++ b/test/environment-subdomain/environment-subdomain.js
@@ -142,13 +142,14 @@ describe('EnvironmentSubdomain', () => {
                 expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, '-foo')).to.equal(originalUrl);
             });
 
-            it('should create URL with hyphenated subdomain', () => {
+            it('should return original URL for non-pl hyphenated subdomain', () => {
                 const originalUrl = 'https://api.sandbox.checkout.com';
-                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test-123')).to.equal('https://test-123.api.sandbox.checkout.com');
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test-123')).to.equal(originalUrl);
             });
 
-            it('should create URL with pl-abc123 subdomain', () => {
+            it('should create URL with PrivateLink pl-{prefix} subdomain', () => {
                 const originalUrl = 'https://api.sandbox.checkout.com';
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'pl-vkuhvk4v')).to.equal('https://pl-vkuhvk4v.api.sandbox.checkout.com');
                 expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'pl-abc123')).to.equal('https://pl-abc123.api.sandbox.checkout.com');
             });
 
@@ -206,11 +207,8 @@ describe('EnvironmentSubdomain', () => {
                 expect(EnvironmentSubdomain.isValidSubdomain('12345678901')).to.be.true;
             });
 
-            it('should validate hyphenated subdomain', () => {
-                expect(EnvironmentSubdomain.isValidSubdomain('test-123')).to.be.true;
-            });
-
-            it('should validate pl-abc123 subdomain', () => {
+            it('should validate PrivateLink pl-{prefix} subdomain', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('pl-vkuhvk4v')).to.be.true;
                 expect(EnvironmentSubdomain.isValidSubdomain('pl-abc123')).to.be.true;
             });
         });
@@ -244,6 +242,15 @@ describe('EnvironmentSubdomain', () => {
 
             it('should reject subdomain with leading hyphen', () => {
                 expect(EnvironmentSubdomain.isValidSubdomain('-foo')).to.be.false;
+            });
+
+            it('should reject non-pl hyphenated subdomain', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('test-123')).to.be.false;
+                expect(EnvironmentSubdomain.isValidSubdomain('foo-bar')).to.be.false;
+            });
+
+            it('should reject bare pl- with no prefix', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('pl-')).to.be.false;
             });
 
             it('should reject subdomain with spaces', () => {

--- a/test/environment-subdomain/environment-subdomain.js
+++ b/test/environment-subdomain/environment-subdomain.js
@@ -125,11 +125,31 @@ describe('EnvironmentSubdomain', () => {
                 expect(result).to.equal(originalUrl);
             });
 
-            it('should return original URL for subdomain with special characters', () => {
+            it('should return original URL for subdomain with invalid special characters', () => {
                 const originalUrl = 'https://api.sandbox.checkout.com';
-                const result = EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test-123');
-                
-                expect(result).to.equal(originalUrl);
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test_123')).to.equal(originalUrl);
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test@123')).to.equal(originalUrl);
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test.123')).to.equal(originalUrl);
+            });
+
+            it('should return original URL for subdomain with trailing hyphen', () => {
+                const originalUrl = 'https://api.sandbox.checkout.com';
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'foo-')).to.equal(originalUrl);
+            });
+
+            it('should return original URL for subdomain with leading hyphen', () => {
+                const originalUrl = 'https://api.sandbox.checkout.com';
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, '-foo')).to.equal(originalUrl);
+            });
+
+            it('should create URL with hyphenated subdomain', () => {
+                const originalUrl = 'https://api.sandbox.checkout.com';
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'test-123')).to.equal('https://test-123.api.sandbox.checkout.com');
+            });
+
+            it('should create URL with pl-abc123 subdomain', () => {
+                const originalUrl = 'https://api.sandbox.checkout.com';
+                expect(EnvironmentSubdomain.createUrlWithSubdomain(originalUrl, 'pl-abc123')).to.equal('https://pl-abc123.api.sandbox.checkout.com');
             });
 
             it('should return original URL for subdomain with spaces', () => {
@@ -185,6 +205,14 @@ describe('EnvironmentSubdomain', () => {
             it('should validate 11-character subdomain', () => {
                 expect(EnvironmentSubdomain.isValidSubdomain('12345678901')).to.be.true;
             });
+
+            it('should validate hyphenated subdomain', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('test-123')).to.be.true;
+            });
+
+            it('should validate pl-abc123 subdomain', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('pl-abc123')).to.be.true;
+            });
         });
 
         describe('invalid subdomains', () => {
@@ -204,11 +232,18 @@ describe('EnvironmentSubdomain', () => {
                 expect(EnvironmentSubdomain.isValidSubdomain('ABC12345')).to.be.false;
             });
 
-            it('should reject subdomain with special characters', () => {
-                expect(EnvironmentSubdomain.isValidSubdomain('test-123')).to.be.false;
+            it('should reject subdomain with invalid special characters', () => {
                 expect(EnvironmentSubdomain.isValidSubdomain('test_123')).to.be.false;
                 expect(EnvironmentSubdomain.isValidSubdomain('test@123')).to.be.false;
                 expect(EnvironmentSubdomain.isValidSubdomain('test.123')).to.be.false;
+            });
+
+            it('should reject subdomain with trailing hyphen', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('foo-')).to.be.false;
+            });
+
+            it('should reject subdomain with leading hyphen', () => {
+                expect(EnvironmentSubdomain.isValidSubdomain('-foo')).to.be.false;
             });
 
             it('should reject subdomain with spaces', () => {

--- a/test/identities/aml-screenings/aml-screenings-unit.js
+++ b/test/identities/aml-screenings/aml-screenings-unit.js
@@ -7,7 +7,7 @@ const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
 
 describe('Unit::AML Screenings', () => {
     it('should create an AML screening', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/aml-verifications', {
                 applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
                 configuration_id: 'cnf_tkoi5db4hryu5cei5vwoabr7we'
@@ -43,7 +43,7 @@ describe('Unit::AML Screenings', () => {
     });
 
     it('should get an AML screening', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/aml-verifications/amlv_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'amlv_tkoi5db4hryu5cei5vwoabr7we',
@@ -76,7 +76,7 @@ describe('Unit::AML Screenings', () => {
     });
 
     it('should throw AuthenticationError when creating AML screening with invalid credentials', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/aml-verifications')
             .reply(401);
 
@@ -93,7 +93,7 @@ describe('Unit::AML Screenings', () => {
     });
 
     it('should throw NotFoundError when getting non-existent AML screening', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/aml-verifications/amlv_invalid')
             .reply(404);
 

--- a/test/identities/applicants/applicants-unit.js
+++ b/test/identities/applicants/applicants-unit.js
@@ -7,7 +7,7 @@ const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
 
 describe('Unit::Applicants', () => {
     it('should create an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/applicants', {
                 external_applicant_id: 'ext_osdfdfdb4hryu5cei5vwoabrk5k',
                 email: 'hannah.bret@example.com',
@@ -39,7 +39,7 @@ describe('Unit::Applicants', () => {
     });
 
     it('should get an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/applicants/aplt_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
@@ -65,7 +65,7 @@ describe('Unit::Applicants', () => {
     });
 
     it('should update an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .patch('/applicants/aplt_tkoi5db4hryu5cei5vwoabr7we', {
                 email: 'hannah.updated@example.com',
                 external_applicant_name: 'Hannah Bret Updated'
@@ -98,7 +98,7 @@ describe('Unit::Applicants', () => {
     });
 
     it('should anonymize an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/applicants/aplt_tkoi5db4hryu5cei5vwoabr7we/anonymize')
             .reply(200, {
                 id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
@@ -122,7 +122,7 @@ describe('Unit::Applicants', () => {
     });
 
     it('should throw AuthenticationError when creating applicant with invalid credentials', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/applicants')
             .reply(401);
 
@@ -140,7 +140,7 @@ describe('Unit::Applicants', () => {
     });
 
     it('should throw NotFoundError when getting non-existent applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/applicants/aplt_invalid')
             .reply(404);
 

--- a/test/identities/delegation/delegation-unit.js
+++ b/test/identities/delegation/delegation-unit.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import nock from 'nock';
 
 const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
-const BASE = 'https://identity-verification.api.sandbox.checkout.com';
+const BASE = 'https://identity-verification.sandbox.checkout.com';
 
 describe('Identities - Backwards Compatibility Delegation', () => {
     afterEach(() => {

--- a/test/identities/face-authentications/face-authentications-unit.js
+++ b/test/identities/face-authentications/face-authentications-unit.js
@@ -7,7 +7,7 @@ const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
 
 describe('Unit::Face Authentications', () => {
     it('should create a face authentication', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/face-authentications', {
                 applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
                 configuration_id: 'cnf_tkoi5db4hryu5cei5vwoabr7we'
@@ -42,7 +42,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should get a face authentication', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/face-authentications/fav_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'fav_tkoi5db4hryu5cei5vwoabr7we',
@@ -84,7 +84,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should list face authentication attempts', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/face-authentications/fav_tkoi5db4hryu5cei5vwoabr7we/attempts')
             .reply(200, {
                 total_count: 2,
@@ -132,7 +132,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should get a specific face authentication attempt', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/face-authentications/fav_tkoi5db4hryu5cei5vwoabr7we/attempts/fatp_nk1wbmmczqumwt95k3v39mhbh2w')
             .reply(200, {
                 id: 'fatp_nk1wbmmczqumwt95k3v39mhbh2w',
@@ -170,7 +170,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should create a face authentication attempt', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/face-authentications/fav_tkoi5db4hryu5cei5vwoabr7we/attempts', {
                 selfie: 'data:image/jpeg;base64,/9j/4AAQSkZJRg...'
             })
@@ -208,7 +208,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should anonymize a face authentication', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/face-authentications/fav_tkoi5db4hryu5cei5vwoabr7we/anonymize')
             .reply(200, {
                 id: 'fav_tkoi5db4hryu5cei5vwoabr7we',
@@ -247,7 +247,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should throw AuthenticationError when creating face authentication with invalid credentials', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/face-authentications')
             .reply(401);
 
@@ -264,7 +264,7 @@ describe('Unit::Face Authentications', () => {
     });
 
     it('should throw NotFoundError when getting non-existent face authentication', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/face-authentications/fav_invalid')
             .reply(404);
 

--- a/test/identities/id-document-verifications/id-document-verifications-unit.js
+++ b/test/identities/id-document-verifications/id-document-verifications-unit.js
@@ -7,7 +7,7 @@ const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
 
 describe('Unit::ID Document Verifications', () => {
     it('should create an ID document verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/id-document-verifications', {
                 applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
                 configuration_id: 'cnf_tkoi5db4hryu5cei5vwoabr7we'
@@ -56,7 +56,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should get an ID document verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/id-document-verifications/iddv_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'iddv_tkoi5db4hryu5cei5vwoabr7we',
@@ -101,7 +101,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should list ID document verification attempts', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/id-document-verifications/iddv_tkoi5db4hryu5cei5vwoabr7we/attempts')
             .reply(200, {
                 total_count: 2,
@@ -145,7 +145,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should get a specific ID document verification attempt', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/id-document-verifications/iddv_tkoi5db4hryu5cei5vwoabr7we/attempts/datp_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'datp_tkoi5db4hryu5cei5vwoabr7we',
@@ -171,7 +171,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should create an ID document verification attempt', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/id-document-verifications/iddv_tkoi5db4hryu5cei5vwoabr7we/attempts', {
                 document_front: 'data:image/jpeg;base64,/9j/4AAQSkZJRg...',
                 document_back: 'data:image/jpeg;base64,/9j/4AAQSkZJRg...'
@@ -203,7 +203,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should get ID document verification PDF report', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/id-document-verifications/iddv_tkoi5db4hryu5cei5vwoabr7we/pdf-report')
             .reply(200, {
                 pdf_report: 'https://www.example.com/pdf',
@@ -220,7 +220,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should anonymize an ID document verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/id-document-verifications/iddv_tkoi5db4hryu5cei5vwoabr7we/anonymize')
             .reply(200, {
                 id: 'iddv_tkoi5db4hryu5cei5vwoabr7we',
@@ -259,7 +259,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should throw AuthenticationError when creating ID document verification with invalid credentials', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/id-document-verifications')
             .reply(401);
 
@@ -276,7 +276,7 @@ describe('Unit::ID Document Verifications', () => {
     });
 
     it('should throw NotFoundError when getting non-existent ID document verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/id-document-verifications/idv_invalid')
             .reply(404);
 

--- a/test/identities/identity-verifications/identity-verifications-unit.js
+++ b/test/identities/identity-verifications/identity-verifications-unit.js
@@ -7,7 +7,7 @@ const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
 
 describe('Unit::Identity Verifications', () => {
     it('should create an identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/identity-verifications', {
                 applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
                 declared_data: {
@@ -61,7 +61,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should create and start an identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/create-and-open-idv', {
                 applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
                 configuration_id: 'cnf_tkoi5db4hryu5cei5vwoabr7we'
@@ -102,7 +102,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should get an identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'idv_tkoi5db4hryu5cei5vwoabr7we',
@@ -160,7 +160,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should create an identity verification attempt', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we/attempts')
             .reply(201, {
                 id: 'iatp_tkoi5db4hryu5cei5vwoabrPoQ',
@@ -197,7 +197,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should list identity verification attempts', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we/attempts')
             .reply(200, {
                 total_count: 2,
@@ -245,7 +245,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should get a specific identity verification attempt', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we/attempts/iatp_tkoi5db4hryu5cei5vwoabrPoQ')
             .reply(200, {
                 id: 'iatp_tkoi5db4hryu5cei5vwoabrPoQ',
@@ -288,7 +288,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should anonymize an identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we/anonymize')
             .reply(200, {
                 id: 'idv_tkoi5db4hryu5cei5vwoabr7we',
@@ -339,7 +339,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should get identity verification PDF report', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we/pdf-report')
             .reply(200, Buffer.from('PDF content'), {
                 'content-type': 'application/pdf'
@@ -354,7 +354,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should throw AuthenticationError when creating identity verification with invalid credentials', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/identity-verifications')
             .reply(401);
 
@@ -373,7 +373,7 @@ describe('Unit::Identity Verifications', () => {
     });
 
     it('should throw NotFoundError when getting non-existent identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/identity-verifications/idv_invalid')
             .reply(404);
 

--- a/test/identities/submodules/submodules-unit.js
+++ b/test/identities/submodules/submodules-unit.js
@@ -7,7 +7,7 @@ const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
 
 describe('Identities - Applicants', () => {
     it('should create an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/applicants')
             .reply(201, {
                 id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
@@ -30,7 +30,7 @@ describe('Identities - Applicants', () => {
     });
 
     it('should get an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/applicants/aplt_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
@@ -51,7 +51,7 @@ describe('Identities - Applicants', () => {
     });
 
     it('should update an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .patch('/applicants/aplt_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
@@ -76,7 +76,7 @@ describe('Identities - Applicants', () => {
     });
 
     it('should anonymize an applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/applicants/aplt_tkoi5db4hryu5cei5vwoabr7we/anonymize')
             .reply(200, {
                 id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
@@ -95,7 +95,7 @@ describe('Identities - Applicants', () => {
     });
 
     it('should throw auth error creating applicant', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/applicants')
             .reply(401);
 
@@ -114,7 +114,7 @@ describe('Identities - Applicants', () => {
 
 describe('Identities - Identity Verifications', () => {
     it('should create an identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/identity-verifications')
             .reply(201, {
                 id: 'idv_tkoi5db4hryu5cei5vwoabr7we',
@@ -141,7 +141,7 @@ describe('Identities - Identity Verifications', () => {
     });
 
     it('should get an identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .get('/identity-verifications/idv_tkoi5db4hryu5cei5vwoabr7we')
             .reply(200, {
                 id: 'idv_tkoi5db4hryu5cei5vwoabr7we',
@@ -162,7 +162,7 @@ describe('Identities - Identity Verifications', () => {
     });
 
     it('should throw auth error creating identity verification', async () => {
-        nock('https://identity-verification.api.sandbox.checkout.com')
+        nock('https://identity-verification.sandbox.checkout.com')
             .post('/identity-verifications')
             .reply(401);
 


### PR DESCRIPTION
## Summary

The identity-verification URL constants pointed at `identity-verification.api.{sandbox.,}checkout.com` (extra `.api.`), which is not the host defined in the swagger spec. This PR fixes the constants to use `identity-verification.{sandbox.,}checkout.com` and updates all `nock` mocks in the identities test suite to match. It also tightens the `EnvironmentSubdomain` regex to match the AWS PrivateLink prefix format documented at https://www.checkout.com/docs/developer-resources/api/private-connections/aws-privatelink — `^(?:pl-)?[a-z0-9]+$` (alphanumeric, optionally prefixed by the literal `pl-`).

## Changes

- `src/config.js` — fixes `IDENTITY_VERIFICATION_SANDBOX_URL` and `IDENTITY_VERIFICATION_LIVE_URL` host
- `src/EnvironmentSubdomain.js` — tightens regex to `^(?:pl-)?[a-z0-9]+$`
- `test/environment-subdomain/environment-subdomain.js` — updates the corpus: `test-123`/`foo-bar` rejected, `pl-vkuhvk4v` (docs example) and `pl-abc123` accepted, `pl-` (bare) rejected
- `test/identities/aml-screenings/aml-screenings-unit.js` — nock URL fix
- `test/identities/applicants/applicants-unit.js` — nock URL fix
- `test/identities/delegation/delegation-unit.js` — nock URL fix
- `test/identities/face-authentications/face-authentications-unit.js` — nock URL fix
- `test/identities/id-document-verifications/id-document-verifications-unit.js` — nock URL fix
- `test/identities/identity-verifications/identity-verifications-unit.js` — nock URL fix
- `test/identities/submodules/submodules-unit.js` — nock URL fix

## API Reference

- `https://identity-verification.checkout.com` / `https://identity-verification.sandbox.checkout.com` — identity services (`/applicants`, `/identity-verifications`, `/aml-verifications`, `/face-authentications`, `/id-document-verifications`)
- `https://pl-{prefix}.api.{sandbox.,}checkout.com` — AWS PrivateLink subdomain format

## Breaking changes

- None for the URL fix — the previous identity URL was not reachable on production, so any user attempting these endpoints would already be failing.
- The subdomain regex is now stricter: arbitrary hyphenated subdomains like `test-123` or `foo-bar-baz` are rejected. Only plain alphanumeric or the literal PrivateLink form (`pl-{prefix}`) are accepted.

## README

Not affected.