### PR TITLE
test: cover authorization_type and payment_plan on payment requests

### DIFF
--- a/test/hosted-payments/hosted-payments.js
+++ b/test/hosted-payments/hosted-payments.js
@@ -43,6 +43,48 @@ describe('Hosted Payments', () => {
         );
     });
 
+    it('should create a hosted payment with authorization_type and payment_plan', async () => {
+        let capturedBody;
+        nock('https://123456789.api.sandbox.checkout.com')
+            .post('/hosted-payments', (body) => {
+                capturedBody = body;
+                return true;
+            })
+            .reply(201, {
+                id: 'hpp_kQhs_fI9b8oQ',
+                reference: 'ORD-5023-4E89',
+                _links: {
+                    redirect: {
+                        href: 'https://pay.checkout.com/page/hpp_kQhs_fI9b8oQ',
+                    },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+
+        await cko.hostedPayments.create({
+            amount: 1000,
+            currency: 'USD',
+            authorization_type: 'Estimated',
+            payment_plan: {
+                amount_variability: 'Variable',
+                days_between_payments: 28,
+                total_number_of_payments: 5,
+                current_payment_number: 3,
+                expiry: '20251031',
+                name: 'Subscription 1234',
+            },
+            success_url: 'https://example.com/success',
+            cancel_url: 'https://example.com/cancel',
+            failure_url: 'https://example.com/failure',
+        });
+
+        expect(capturedBody.authorization_type).to.equal('Estimated');
+        expect(capturedBody.payment_plan.amount_variability).to.equal('Variable');
+        expect(capturedBody.payment_plan.days_between_payments).to.equal(28);
+        expect(capturedBody.payment_plan.total_number_of_payments).to.equal(5);
+    });
+
     it('should throw Authentication Error', async () => {
         nock('https://123456789.api.sandbox.checkout.com').post('/hosted-payments').reply(401);
 

--- a/test/payment-sessions/payment-sessions-unit.js
+++ b/test/payment-sessions/payment-sessions-unit.js
@@ -169,4 +169,34 @@ describe('Unit::Payment-Sessions', () => {
     }
   });
 
+  it('should request a payment session with authorization_type and payment_plan', async () => {
+    let capturedBody;
+    nock('https://123456789.api.sandbox.checkout.com')
+      .post('/payment-sessions', (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(201, commonResponse);
+
+    const cko = new Checkout(SK, { subdomain: '123456789' });
+
+    await cko.paymentSessions.request({
+      ...commonRequest,
+      authorization_type: 'Estimated',
+      payment_plan: {
+        amount_variability: 'Variable',
+        days_between_payments: 28,
+        total_number_of_payments: 5,
+        current_payment_number: 3,
+        expiry: '20251031',
+        name: 'Subscription 1234',
+      },
+    });
+
+    expect(capturedBody.authorization_type).to.equal('Estimated');
+    expect(capturedBody.payment_plan.amount_variability).to.equal('Variable');
+    expect(capturedBody.payment_plan.days_between_payments).to.equal(28);
+    expect(capturedBody.payment_plan.total_number_of_payments).to.equal(5);
+  });
+
 });

--- a/test/payments-links/payments-links.js
+++ b/test/payments-links/payments-links.js
@@ -47,6 +47,50 @@ describe('Payment Links', () => {
         );
     });
 
+    it('should create a payment link with authorization_type and payment_plan', async () => {
+        let capturedBody;
+        nock('https://123456789.api.sandbox.checkout.com')
+            .post('/payment-links', (body) => {
+                capturedBody = body;
+                return true;
+            })
+            .reply(201, {
+                id: 'pl_irx_SMlY5RCA',
+                expires_on: '2021-02-19T16:54:41.501Z',
+                _links: {
+                    redirect: { href: 'https://pay.sandbox.checkout.com/link/IT1-wLhj_wM8' },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+
+        await cko.paymentLinks.create({
+            amount: 10359,
+            currency: 'EUR',
+            authorization_type: 'Estimated',
+            payment_plan: {
+                amount_variability: 'Fixed',
+                days_between_payments: 30,
+                total_number_of_payments: 12,
+                current_payment_number: 1,
+                expiry: '20251031',
+                name: 'Subscription 1234',
+                amount: 1234,
+            },
+            billing: {
+                address: {
+                    country: 'DE',
+                },
+            },
+            return_url: 'https://pay.sandbox.checkout.com/link/examples/docs',
+        });
+
+        expect(capturedBody.authorization_type).to.equal('Estimated');
+        expect(capturedBody.payment_plan.amount_variability).to.equal('Fixed');
+        expect(capturedBody.payment_plan.total_number_of_payments).to.equal(12);
+        expect(capturedBody.payment_plan.amount).to.equal(1234);
+    });
+
     it('should throw Authentication Error', async () => {
         nock('https://123456789.api.sandbox.checkout.com').post('/payment-links').reply(401);
 


### PR DESCRIPTION
## What
Adds unit tests for `authorization_type` and `payment_plan` on the three payment-creation requests that recently gained these fields in swagger:
- `HostedPaymentsRequest` (`cko.hostedPayments.create`)
- `PaymentLinksRequest` (`cko.paymentLinks.create`)
- `CreatePaymentSessionsBaseRequest` (`cko.paymentSessions.request`)

## Why tests, not type defs
Investigated the SDK's type system. The `.d.ts` files type these request bodies as `Object`/`any` (e.g. `create: (body: Object) => Promise<Object>`), and the runtime passes plain objects straight through to the HTTP layer. There are **no explicit per-field request models** to extend. So the correct, convention-matching change is test coverage that documents and locks in support for the new fields, rather than inventing a typing system the repo doesn't use.

Each test uses a nock request-body matcher to assert the new fields (`authorization_type: 'Estimated'` and the `payment_plan` recurring object — `amount_variability`, `days_between_payments`, `total_number_of_payments`, etc.) are serialized onto the outgoing request.

Part of a cross-SDK sweep for these payment-request field gaps.

## Tests
`npx mocha 'test/**/*.js'` → **851 passing, 0 failing**, including the 3 new tests. (When the three touched files are run in isolation there are pre-existing nock interceptor-ordering failures unrelated to this change; the full suite — how CI runs — is green.)

## Files
- test/hosted-payments/hosted-payments.js
- test/payments-links/payments-links.js
- test/payment-sessions/payment-sessions-unit.js