### PR TITLE
Release 3.6.0 - Accounts API schema version via Accept header + Issuing surface alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkout-sdk-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkout-sdk-node",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-sdk-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Official Node.js SDK for Checkout.com payment gateway - Full API coverage with TypeScript support",
   "type": "module",
   "engines": {


### PR DESCRIPTION
*** BREAKING CHANGES ***

This release introduces a shared internal helper for setting the Accounts API schema-version Accept header and updates the Platforms API to consistently include this header in all relevant `/accounts/entities` operations. It also adds comprehensive tests to ensure the correct Accept header is sent by default and when overridden, and updates test fixtures to the latest v3.0 schema.

**Accounts API Accept Header Handling:**

* Added a new internal helper function `getConfigWithAcceptHeader` in `accept-header.js` to construct request configs with the correct schema-version Accept header for `/accounts/entities` endpoints.
* Refactored `subentity.js` and `entity-requirements.js` to use the shared `getConfigWithAcceptHeader`, ensuring all entity-related requests send the correct Accept header. [[1]](diffhunk://#diff-327e41aee290a975120ea06c70c980d1d4ea5fc25372932e49c7e84eea249646L3-R3) [[2]](diffhunk://#diff-a732c2cf669a4a43b55b99e04aeb8d5992c4ae28301323b43a001a7ce6899dffR3)
* Updated `getEntityRequirements` in `entity-requirements.js` and its usage in `platforms.js` to accept an optional `schemaVersion` parameter, defaulting to '3.0'. [[1]](diffhunk://#diff-a732c2cf669a4a43b55b99e04aeb8d5992c4ae28301323b43a001a7ce6899dffR21-R29) [[2]](diffhunk://#diff-b7f33a54903e5ff95d5d9f275cf1821266da229dde814e33d24e38fe518f0f41L110-R111)

**Testing and Schema Updates:**

* Added a new test suite `accept-header-unit.js` to verify that all entity operations send the correct Accept header by default and when an explicit schema version is provided.
* Updated test fixtures in `subentity-unit.js` to use the v3.0 schema, including nested `individual` objects for representatives, new company and processing details fields, and updated contact details. [[1]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R53-R75) [[2]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R90-L97) [[3]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R163-R185) [[4]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R200-L176) [[5]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R266-R288) [[6]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R303-L249) [[7]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R526-R548) [[8]](diffhunk://#diff-d26a7c4eccd8b1e9f0ddcd7b01b57393f216fa40b5a38989dddb37930f970d83R563-L480)

---------------------------------------------------------------------------------------------------------------

An also this release aligns the Issuing surface with the **2026-06-29** API spec. The Node SDK is untyped (all bodies are plain `object`), so only client-method-level changes apply — field/schema changes flow through the object bodies unchanged.

## Disputes
- **Add `amendDispute(disputeId, body)`** — `POST /issuing/disputes/{disputeId}/amend` (new, non-deprecated). Body supports `reason`, `amount`, `evidence`, `fraud_details`, `reason_change_justification`, `action_response`.
- **`escalateDispute`** now accepts an optional `body` (for `fraud_details`).
- **Correct `submitDispute`** — the spec keeps `POST /issuing/disputes/{disputeId}/submit` present with `deprecated: true`. It was previously (incorrectly) documented as *removed / returns 404 on 2026-04-15*. Now marked deprecated-but-present, message points at create / amend, and it accepts an optional body. Its existing test stays.

## Cards (⚠️ breaking)
- **Remove `scheduleCardRevocation` and `cancelScheduledCardRevocation`** — `POST`/`DELETE /issuing/cards/{cardId}/schedule-revocation` were removed from the API. Revocation scheduling is now expressed via the update-card request's `revocation_date`.

## Other
- Updated `.d.ts` declarations for all touched methods.
- Removed the 4 schedule-revocation unit tests; added an `amendDispute` unit test (all 6 fields incl. `action_response`) and enriched the escalate test with `fraud_details`.

## Testing
Full suite: **845 passing, 0 failing, 84 pending** (`npm test`). No lingering `schedule-revocation` references in `src`/`test`/`types`.

## Breaking changes for release notes
- Removal of `scheduleCardRevocation` / `cancelScheduledCardRevocation`.