### PR TITLE
fix(forward): move secret item path to /secrets/{name} (INT-1666)

### DIFF
--- a/src/api/forward/forward.js
+++ b/src/api/forward/forward.js
@@ -1,6 +1,10 @@
 import { determineError } from '../../services/errors.js';
 import { _delete, get, patch, post } from '../../services/http.js';
 
+// Path segments appended to the forward host root (config.forwardUrl).
+const FORWARD_PATH = 'forward';
+const SECRETS_PATH = 'secrets';
+
 /**
  * Class dealing with the /forward endpoint
  *
@@ -25,7 +29,7 @@ export default class Forward {
         try {
             const response = await post(
                 this.config.httpClient,
-                this.config.forwardUrl,
+                `${this.config.forwardUrl}${FORWARD_PATH}`,
                 this.config,
                 this.config.sk,
                 body
@@ -48,7 +52,7 @@ export default class Forward {
         try {
             const response = await get(
                 this.config.httpClient,
-                `${this.config.forwardUrl}/${id}`,
+                `${this.config.forwardUrl}${FORWARD_PATH}/${id}`,
                 this.config,
                 this.config.sk
             );
@@ -74,7 +78,7 @@ export default class Forward {
         try {
             const response = await post(
                 this.config.httpClient,
-                this.config.forwardSecretsUrl,
+                `${this.config.forwardUrl}${SECRETS_PATH}`,
                 this.config,
                 this.config.sk,
                 body
@@ -95,7 +99,7 @@ export default class Forward {
         try {
             const response = await get(
                 this.config.httpClient,
-                this.config.forwardSecretsUrl,
+                `${this.config.forwardUrl}${SECRETS_PATH}`,
                 this.config,
                 this.config.sk
             );
@@ -121,7 +125,7 @@ export default class Forward {
         try {
             const response = await patch(
                 this.config.httpClient,
-                `${this.config.forwardSecretsUrl}/${name}`,
+                `${this.config.forwardUrl}${SECRETS_PATH}/${name}`,
                 this.config,
                 this.config.sk,
                 body
@@ -143,7 +147,7 @@ export default class Forward {
         try {
             const response = await _delete(
                 this.config.httpClient,
-                `${this.config.forwardSecretsUrl}/${name}`,
+                `${this.config.forwardUrl}${SECRETS_PATH}/${name}`,
                 this.config,
                 this.config.sk
             );

--- a/src/api/forward/forward.js
+++ b/src/api/forward/forward.js
@@ -74,7 +74,7 @@ export default class Forward {
         try {
             const response = await post(
                 this.config.httpClient,
-                `${this.config.forwardUrl}/secrets`,
+                this.config.forwardSecretsUrl,
                 this.config,
                 this.config.sk,
                 body
@@ -95,7 +95,7 @@ export default class Forward {
         try {
             const response = await get(
                 this.config.httpClient,
-                `${this.config.forwardUrl}/secrets`,
+                this.config.forwardSecretsUrl,
                 this.config,
                 this.config.sk
             );

--- a/src/api/forward/forward.js
+++ b/src/api/forward/forward.js
@@ -121,7 +121,7 @@ export default class Forward {
         try {
             const response = await patch(
                 this.config.httpClient,
-                `${this.config.forwardUrl}/secrets/${name}`,
+                `${this.config.forwardSecretsUrl}/${name}`,
                 this.config,
                 this.config.sk,
                 body
@@ -143,7 +143,7 @@ export default class Forward {
         try {
             const response = await _delete(
                 this.config.httpClient,
-                `${this.config.forwardUrl}/secrets/${name}`,
+                `${this.config.forwardSecretsUrl}/${name}`,
                 this.config,
                 this.config.sk
             );

--- a/src/api/forward/forward.js
+++ b/src/api/forward/forward.js
@@ -29,7 +29,7 @@ export default class Forward {
         try {
             const response = await post(
                 this.config.httpClient,
-                `${this.config.forwardUrl}${FORWARD_PATH}`,
+                `${this.config.forwardUrl}/${FORWARD_PATH}`,
                 this.config,
                 this.config.sk,
                 body
@@ -52,7 +52,7 @@ export default class Forward {
         try {
             const response = await get(
                 this.config.httpClient,
-                `${this.config.forwardUrl}${FORWARD_PATH}/${id}`,
+                `${this.config.forwardUrl}/${FORWARD_PATH}/${id}`,
                 this.config,
                 this.config.sk
             );
@@ -78,7 +78,7 @@ export default class Forward {
         try {
             const response = await post(
                 this.config.httpClient,
-                `${this.config.forwardUrl}${SECRETS_PATH}`,
+                `${this.config.forwardUrl}/${SECRETS_PATH}`,
                 this.config,
                 this.config.sk,
                 body
@@ -99,7 +99,7 @@ export default class Forward {
         try {
             const response = await get(
                 this.config.httpClient,
-                `${this.config.forwardUrl}${SECRETS_PATH}`,
+                `${this.config.forwardUrl}/${SECRETS_PATH}`,
                 this.config,
                 this.config.sk
             );
@@ -125,7 +125,7 @@ export default class Forward {
         try {
             const response = await patch(
                 this.config.httpClient,
-                `${this.config.forwardUrl}${SECRETS_PATH}/${name}`,
+                `${this.config.forwardUrl}/${SECRETS_PATH}/${name}`,
                 this.config,
                 this.config.sk,
                 body
@@ -147,7 +147,7 @@ export default class Forward {
         try {
             const response = await _delete(
                 this.config.httpClient,
-                `${this.config.forwardUrl}${SECRETS_PATH}/${name}`,
+                `${this.config.forwardUrl}/${SECRETS_PATH}/${name}`,
                 this.config,
                 this.config.sk
             );

--- a/src/config.js
+++ b/src/config.js
@@ -10,10 +10,10 @@ export const PLATFORMS_FILES_SANDBOX_URL = 'https://files.sandbox.checkout.com/f
 export const TRANSFERS_SANDBOX_URL = 'https://transfers.sandbox.checkout.com/transfers';
 export const TRANSFERS_LIVE_URL = 'https://transfers.checkout.com/transfers';
 
-// Forward host root. The `forward` and `secrets` path segments are appended by
-// the ForwardClient methods (matching every other SDK).
-export const FORWARD_SANDBOX_URL = 'https://forward.sandbox.checkout.com/';
-export const FORWARD_LIVE_URL = 'https://forward.checkout.com/';
+// Forward host root (no trailing slash). The `forward` and `secrets` path
+// segments are appended by the ForwardClient methods (matching every other SDK).
+export const FORWARD_SANDBOX_URL = 'https://forward.sandbox.checkout.com';
+export const FORWARD_LIVE_URL = 'https://forward.checkout.com';
 
 export const BALANCES_SANDBOX_URL = 'https://balances.sandbox.checkout.com/balances';
 export const BALANCES_LIVE_URL = 'https://balances.checkout.com/balances';

--- a/src/config.js
+++ b/src/config.js
@@ -10,12 +10,10 @@ export const PLATFORMS_FILES_SANDBOX_URL = 'https://files.sandbox.checkout.com/f
 export const TRANSFERS_SANDBOX_URL = 'https://transfers.sandbox.checkout.com/transfers';
 export const TRANSFERS_LIVE_URL = 'https://transfers.checkout.com/transfers';
 
-export const FORWARD_SANDBOX_URL = 'https://forward.sandbox.checkout.com/forward';
-export const FORWARD_LIVE_URL = 'https://forward.checkout.com/forward';
-
-// Forward secrets endpoints live at the forward host root (no /forward segment).
-export const FORWARD_SECRETS_SANDBOX_URL = 'https://forward.sandbox.checkout.com/secrets';
-export const FORWARD_SECRETS_LIVE_URL = 'https://forward.checkout.com/secrets';
+// Forward host root. The `forward` and `secrets` path segments are appended by
+// the ForwardClient methods (matching every other SDK).
+export const FORWARD_SANDBOX_URL = 'https://forward.sandbox.checkout.com/';
+export const FORWARD_LIVE_URL = 'https://forward.checkout.com/';
 
 export const BALANCES_SANDBOX_URL = 'https://balances.sandbox.checkout.com/balances';
 export const BALANCES_LIVE_URL = 'https://balances.checkout.com/balances';

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,10 @@ export const TRANSFERS_LIVE_URL = 'https://transfers.checkout.com/transfers';
 export const FORWARD_SANDBOX_URL = 'https://forward.sandbox.checkout.com/forward';
 export const FORWARD_LIVE_URL = 'https://forward.checkout.com/forward';
 
+// Forward secrets endpoints live at the forward host root (no /forward segment).
+export const FORWARD_SECRETS_SANDBOX_URL = 'https://forward.sandbox.checkout.com/secrets';
+export const FORWARD_SECRETS_LIVE_URL = 'https://forward.checkout.com/secrets';
+
 export const BALANCES_SANDBOX_URL = 'https://balances.sandbox.checkout.com/balances';
 export const BALANCES_LIVE_URL = 'https://balances.checkout.com/balances';
 

--- a/src/special-urls.js
+++ b/src/special-urls.js
@@ -13,9 +13,6 @@ export function calculateSpecialUrls(environment) {
             : CONFIG.PLATFORMS_FILES_LIVE_URL,
         transfersUrl: isSandbox ? CONFIG.TRANSFERS_SANDBOX_URL : CONFIG.TRANSFERS_LIVE_URL,
         forwardUrl: isSandbox ? CONFIG.FORWARD_SANDBOX_URL : CONFIG.FORWARD_LIVE_URL,
-        forwardSecretsUrl: isSandbox
-            ? CONFIG.FORWARD_SECRETS_SANDBOX_URL
-            : CONFIG.FORWARD_SECRETS_LIVE_URL,
         balancesUrl: isSandbox ? CONFIG.BALANCES_SANDBOX_URL : CONFIG.BALANCES_LIVE_URL,
         identityVerificationUrl: isSandbox
             ? CONFIG.IDENTITY_VERIFICATION_SANDBOX_URL

--- a/src/special-urls.js
+++ b/src/special-urls.js
@@ -13,6 +13,9 @@ export function calculateSpecialUrls(environment) {
             : CONFIG.PLATFORMS_FILES_LIVE_URL,
         transfersUrl: isSandbox ? CONFIG.TRANSFERS_SANDBOX_URL : CONFIG.TRANSFERS_LIVE_URL,
         forwardUrl: isSandbox ? CONFIG.FORWARD_SANDBOX_URL : CONFIG.FORWARD_LIVE_URL,
+        forwardSecretsUrl: isSandbox
+            ? CONFIG.FORWARD_SECRETS_SANDBOX_URL
+            : CONFIG.FORWARD_SECRETS_LIVE_URL,
         balancesUrl: isSandbox ? CONFIG.BALANCES_SANDBOX_URL : CONFIG.BALANCES_LIVE_URL,
         identityVerificationUrl: isSandbox
             ? CONFIG.IDENTITY_VERIFICATION_SANDBOX_URL

--- a/test/forward/forward-unit.js
+++ b/test/forward/forward-unit.js
@@ -336,7 +336,7 @@ describe('Unit::Forward', () => {
 
     it('should update a secret', async () => {
         nock('https://forward.sandbox.checkout.com')
-            .patch('/forward/secrets/secret_name', {
+            .patch('/secrets/secret_name', {
                 value: 'new_plaintext',
                 entity_id: 'ent_67890'
             })
@@ -364,7 +364,7 @@ describe('Unit::Forward', () => {
 
     it('should delete a secret', async () => {
         nock('https://forward.sandbox.checkout.com')
-            .delete('/forward/secrets/secret_name')
+            .delete('/secrets/secret_name')
             .reply(204);
 
         const cko = new Checkout(SK);

--- a/test/forward/forward-unit.js
+++ b/test/forward/forward-unit.js
@@ -262,7 +262,7 @@ describe('Unit::Forward', () => {
 
     it('should create a secret', async () => {
         nock('https://forward.sandbox.checkout.com')
-            .post('/forward/secrets', {
+            .post('/secrets', {
                 name: 'secret_name',
                 value: 'plaintext',
                 entity_id: 'ent_12345'
@@ -292,7 +292,7 @@ describe('Unit::Forward', () => {
 
     it('should list secrets', async () => {
         nock('https://forward.sandbox.checkout.com')
-            .get('/forward/secrets')
+            .get('/secrets')
             .reply(200, {
                 data: [
                     {


### PR DESCRIPTION
Completes the Forward secrets path rename (swagger 2026-07-20): the item endpoints **PATCH/DELETE** moved from `/forward/secrets/{name}` to `/secrets/{name}`, dropping the `/forward` prefix so the item matches the collection already on `/secrets`.

Jira: INT-1666
Tests: green (forward suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)