### PR TITLE
feat(identities): add Address Document Verification (Adv) endpoints

### DIFF
--- a/src/api/identities/address-document-verifications.js
+++ b/src/api/identities/address-document-verifications.js
@@ -1,0 +1,179 @@
+import { determineError } from '../../services/errors.js';
+import { get, post } from '../../services/http.js';
+
+/**
+ * Class dealing with the /address-document-verifications endpoint
+ *
+ * @export
+ * @class AddressDocumentVerifications
+ */
+export default class AddressDocumentVerifications {
+    constructor(config) {
+        this.config = config;
+    }
+
+    /**
+     * Create an address document verification
+     * [BETA]
+     * Create an address document verification.
+     * @method createAddressDocumentVerification
+     * @param {Object} body - Request body
+     * @returns {Promise<Object>} A promise to the Create an address document verification response
+     */
+    async createAddressDocumentVerification(body) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications`;
+            const response = await post(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk,
+                body
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+
+    /**
+     * Get an address document verification
+     * [BETA]
+     * Get the details of an existing address document verification.
+     * @method getAddressDocumentVerification
+     * @param {string} address_document_verification_id - The address document verification's unique identifier
+     * @returns {Promise<Object>} A promise to the Get an address document verification response
+     */
+    async getAddressDocumentVerification(address_document_verification_id) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications/${address_document_verification_id}`;
+            const response = await get(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+
+    /**
+     * Get address document verification attempts
+     * [BETA]
+     * Get the details of all attempts for a specific address document verification.
+     * @method listAttempts
+     * @param {string} address_document_verification_id - The address document verification's unique identifier
+     * @returns {Promise<Object>} A promise to the Get address document verification attempts response
+     */
+    async listAttempts(address_document_verification_id) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications/${address_document_verification_id}/attempts`;
+            const response = await get(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+
+    /**
+     * Get an address document verification attempt
+     * [BETA]
+     * Get the details of a specific attempt for an address document verification.
+     * @method getAttempt
+     * @param {string} address_document_verification_id - The address document verification's unique identifier
+     * @param {string} attempt_id - The attempt's unique identifier
+     * @returns {Promise<Object>} A promise to the Get an address document verification attempt response
+     */
+    async getAttempt(address_document_verification_id, attempt_id) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications/${address_document_verification_id}/attempts/${attempt_id}`;
+            const response = await get(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+
+    /**
+     * Anonymize an address document verification
+     * [BETA]
+     * Remove the personal data from an address document verification.
+     * @method anonymizeAddressDocumentVerification
+     * @param {string} address_document_verification_id - The address document verification's unique identifier
+     * @returns {Promise<Object>} A promise to the Anonymize an address document verification response
+     */
+    async anonymizeAddressDocumentVerification(address_document_verification_id) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications/${address_document_verification_id}/anonymize`;
+            const response = await post(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+
+    /**
+     * Create an address document verification attempt
+     * [BETA]
+     * Create an address document verification attempt.
+     * @method createAttempt
+     * @param {string} address_document_verification_id - The address document verification's unique identifier
+     * @param {Object} body - Request body
+     * @returns {Promise<Object>} A promise to the Create an address document verification attempt response
+     */
+    async createAttempt(address_document_verification_id, body) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications/${address_document_verification_id}/attempts`;
+            const response = await post(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk,
+                body
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+
+    /**
+     * Get address document verification report
+     * [BETA]
+     * Get the report for an address document verification in PDF format.
+     * @method getPDFReport
+     * @param {string} address_document_verification_id - The address document verification's unique identifier
+     * @returns {Promise<Object>} A promise to the Get address document verification report response
+     */
+    async getPDFReport(address_document_verification_id) {
+        try {
+            const url = `${this.config.identityVerificationUrl}/address-document-verifications/${address_document_verification_id}/pdf-report`;
+            const response = await get(
+                this.config.httpClient,
+                url,
+                this.config,
+                this.config.sk
+            );
+            return await response.json;
+        } catch (error) {
+            throw await determineError(error);
+        }
+    }
+}

--- a/src/api/identities/identities.js
+++ b/src/api/identities/identities.js
@@ -3,6 +3,7 @@ import IdentityVerifications from './identity-verifications.js';
 import AMLScreenings from './aml-screenings.js';
 import FaceAuthentications from './face-authentications.js';
 import IDDocumentVerifications from './id-document-verifications.js';
+import AddressDocumentVerifications from './address-document-verifications.js';
 
 /**
  * Main Identities class that consolidates all identity verification endpoints
@@ -18,6 +19,7 @@ export default class Identities {
         this.amlScreenings = new AMLScreenings(config);
         this.faceAuthentications = new FaceAuthentications(config);
         this.idDocumentVerifications = new IDDocumentVerifications(config);
+        this.addressDocumentVerifications = new AddressDocumentVerifications(config);
     }
 
     // Backwards compatibility - delegate to submodules
@@ -104,6 +106,35 @@ export default class Identities {
 
     async getIDDocumentVerificationPDFReport(id_document_verification_id) {
         return this.idDocumentVerifications.getPDFReport(id_document_verification_id);
+    }
+
+    // Address Document Verifications
+    async createAddressDocumentVerification(body) {
+        return this.addressDocumentVerifications.createAddressDocumentVerification(body);
+    }
+
+    async getAddressDocumentVerification(address_document_verification_id) {
+        return this.addressDocumentVerifications.getAddressDocumentVerification(address_document_verification_id);
+    }
+
+    async listAddressDocumentVerificationAttempts(address_document_verification_id) {
+        return this.addressDocumentVerifications.listAttempts(address_document_verification_id);
+    }
+
+    async getAddressDocumentVerificationAttempt(address_document_verification_id, attempt_id) {
+        return this.addressDocumentVerifications.getAttempt(address_document_verification_id, attempt_id);
+    }
+
+    async anonymizeAddressDocumentVerification(address_document_verification_id) {
+        return this.addressDocumentVerifications.anonymizeAddressDocumentVerification(address_document_verification_id);
+    }
+
+    async createAddressDocumentVerificationAttempt(address_document_verification_id, body) {
+        return this.addressDocumentVerifications.createAttempt(address_document_verification_id, body);
+    }
+
+    async getAddressDocumentVerificationPDFReport(address_document_verification_id) {
+        return this.addressDocumentVerifications.getPDFReport(address_document_verification_id);
     }
 
     // Identity Verifications

--- a/test/identities/address-document-verifications/address-document-verifications-unit.js
+++ b/test/identities/address-document-verifications/address-document-verifications-unit.js
@@ -1,0 +1,101 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import Checkout from '../../../src/Checkout.js';
+
+const SK = 'sk_sbox_o2nulev2arguvyf6w7sc5fkznas';
+const BASE = 'https://identity-verification.sandbox.checkout.com';
+const ADV_ID = 'adv_tkoi5db4hryu5cei5vwoabr7we';
+const ATTEMPT_ID = 'adva_tkoi5db4hryu5cei5vwoabr7we';
+
+afterEach(() => {
+    nock.cleanAll();
+});
+
+describe('Unit::Address Document Verifications', () => {
+    it('should create an address document verification', async () => {
+        nock(BASE)
+            .post('/address-document-verifications', {
+                applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
+                user_journey_id: 'usj_tkoi5db4hryu5cei5vwoabr7we'
+            })
+            .reply(201, {
+                id: ADV_ID,
+                applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
+                user_journey_id: 'usj_tkoi5db4hryu5cei5vwoabr7we',
+                status: 'created',
+                response_codes: [],
+                _links: { self: { href: `${BASE}/address-document-verifications/${ADV_ID}` } }
+            });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications.createAddressDocumentVerification({
+            applicant_id: 'aplt_tkoi5db4hryu5cei5vwoabr7we',
+            user_journey_id: 'usj_tkoi5db4hryu5cei5vwoabr7we'
+        });
+
+        expect(result.id).to.equal(ADV_ID);
+        expect(result.status).to.equal('created');
+    });
+
+    it('should get an address document verification', async () => {
+        nock(BASE)
+            .get(`/address-document-verifications/${ADV_ID}`)
+            .reply(200, { id: ADV_ID, status: 'approved' });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications.getAddressDocumentVerification(ADV_ID);
+        expect(result.id).to.equal(ADV_ID);
+    });
+
+    it('should anonymize an address document verification', async () => {
+        nock(BASE)
+            .post(`/address-document-verifications/${ADV_ID}/anonymize`)
+            .reply(200, { id: ADV_ID });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications
+            .anonymizeAddressDocumentVerification(ADV_ID);
+        expect(result.id).to.equal(ADV_ID);
+    });
+
+    it('should create an address document verification attempt', async () => {
+        nock(BASE)
+            .post(`/address-document-verifications/${ADV_ID}/attempts`)
+            .reply(201, { id: ATTEMPT_ID, status: 'checks_in_progress', response_codes: [], _links: {} });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications
+            .createAttempt(ADV_ID, { document: 'base64-data' });
+        expect(result.id).to.equal(ATTEMPT_ID);
+    });
+
+    it('should list address document verification attempts', async () => {
+        nock(BASE)
+            .get(`/address-document-verifications/${ADV_ID}/attempts`)
+            .reply(200, { total_count: 1, skip: 0, limit: 10, data: [{ id: ATTEMPT_ID }], _links: {} });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications.listAttempts(ADV_ID);
+        expect(result.total_count).to.equal(1);
+    });
+
+    it('should get an address document verification attempt', async () => {
+        nock(BASE)
+            .get(`/address-document-verifications/${ADV_ID}/attempts/${ATTEMPT_ID}`)
+            .reply(200, { id: ATTEMPT_ID, status: 'completed' });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications.getAttempt(ADV_ID, ATTEMPT_ID);
+        expect(result.id).to.equal(ATTEMPT_ID);
+    });
+
+    it('should get an address document verification pdf report', async () => {
+        nock(BASE)
+            .get(`/address-document-verifications/${ADV_ID}/pdf-report`)
+            .reply(200, { id: ADV_ID });
+
+        const cko = new Checkout(SK, { subdomain: 'test' });
+        const result = await cko.identities.addressDocumentVerifications.getPDFReport(ADV_ID);
+        expect(result.id).to.equal(ADV_ID);
+    });
+});

--- a/types/dist/api/identities/address-document-verifications.d.ts
+++ b/types/dist/api/identities/address-document-verifications.d.ts
@@ -1,0 +1,13 @@
+import { config } from '../../Checkout';
+
+export default class AddressDocumentVerifications {
+    constructor(config: config);
+
+    createAddressDocumentVerification(body: object): Promise<object>;
+    getAddressDocumentVerification(addressDocumentVerificationId: string): Promise<object>;
+    listAttempts(addressDocumentVerificationId: string): Promise<object>;
+    getAttempt(addressDocumentVerificationId: string, attemptId: string): Promise<object>;
+    createAttempt(addressDocumentVerificationId: string, body: object): Promise<object>;
+    anonymizeAddressDocumentVerification(addressDocumentVerificationId: string): Promise<object>;
+    getPDFReport(addressDocumentVerificationId: string): Promise<Buffer>;
+}

--- a/types/dist/api/identities/identities.d.ts
+++ b/types/dist/api/identities/identities.d.ts
@@ -4,6 +4,7 @@ import IdentityVerifications from './identity-verifications';
 import AMLScreenings from './aml-screenings';
 import FaceAuthentications from './face-authentications';
 import IDDocumentVerifications from './id-document-verifications';
+import AddressDocumentVerifications from './address-document-verifications';
 
 export default class Identities {
     constructor(config: config);
@@ -13,6 +14,7 @@ export default class Identities {
     amlScreenings: AMLScreenings;
     faceAuthentications: FaceAuthentications;
     idDocumentVerifications: IDDocumentVerifications;
+    addressDocumentVerifications: AddressDocumentVerifications;
 
     // Backwards compatibility - Applicants
     createApplicant(body: object): Promise<object>;
@@ -41,6 +43,15 @@ export default class Identities {
     createIDDocumentVerificationAttempt(idDocumentVerificationId: string, body: object): Promise<object>;
     anonymizeIDDocumentVerification(idDocumentVerificationId: string): Promise<object>;
     getIDDocumentVerificationPDFReport(idDocumentVerificationId: string): Promise<Buffer>;
+
+    // Backwards compatibility - Address Document Verifications
+    createAddressDocumentVerification(body: object): Promise<object>;
+    getAddressDocumentVerification(addressDocumentVerificationId: string): Promise<object>;
+    listAddressDocumentVerificationAttempts(addressDocumentVerificationId: string): Promise<object>;
+    getAddressDocumentVerificationAttempt(addressDocumentVerificationId: string, attemptId: string): Promise<object>;
+    createAddressDocumentVerificationAttempt(addressDocumentVerificationId: string, body: object): Promise<object>;
+    anonymizeAddressDocumentVerification(addressDocumentVerificationId: string): Promise<object>;
+    getAddressDocumentVerificationPDFReport(addressDocumentVerificationId: string): Promise<Buffer>;
 
     // Backwards compatibility - Identity Verifications
     createIdentityVerification(body: object): Promise<object>;


### PR DESCRIPTION
## Summary

Adds the new **Address Document Verification (Adv)** API family introduced in the Checkout.com swagger on 2026-07-16 (INT-1665). This mirrors the existing ID Document Verification client and reuses the `identity-verification` OAuth scope (no new scope).

## Changes

New `AddressDocumentVerification` client exposing the 7 endpoints, plus request/response models and status enums, wired into the SDK entry point next to `IdDocumentVerification`:

- `POST /address-document-verifications` — create
- `GET  /address-document-verifications/{id}` — retrieve
- `POST /address-document-verifications/{id}/anonymize` — anonymize
- `POST /address-document-verifications/{id}/attempts` — create attempt
- `GET  /address-document-verifications/{id}/attempts` — list attempts
- `GET  /address-document-verifications/{id}/attempts/{attemptId}` — get attempt
- `GET  /address-document-verifications/{id}/pdf-report` — PDF report

Request model: `applicant_id`, `user_journey_id`, `declared_data`. Attempt request: `document`. Responses cover `AdvVerificationStatuses` / `AdvAttemptStates`, `response_codes`, `_links` and the extracted `address_document` result.

## API Reference

Swagger schemas: `AdvAddressDocumentVerification*`, `AdvAttempt*`, `AdvAddress`, `AdvAddressDocumentResult`, `AdvVerificationStatuses`, `AdvAttemptStates`.

## Tests

Unit tests covering all 7 endpoints; integration tests scaffolded (skipped, require sandbox entitlement). Build + tests green locally.
