### PR TITLE
Release 4.1.0 - Forward secrets path fix + Address Document Verification endpoints + challenge indicator docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkout-sdk-node",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkout-sdk-node",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-sdk-node",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Official Node.js SDK for Checkout.com payment gateway - Full API coverage with TypeScript support",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release 4.1.0 bundles three changes: the Forward secrets path fix (#443, INT-1666), the new Address Document Verification endpoints (#444, INT-1665) and the challenge indicator documentation alignment (#445, INT-1667).

## Forward secrets path fix (behaviour change)

Swagger 2026-07-20 completed the rename of the Forward secrets endpoints. Requests now go to the Forward host root, without the `/forward` prefix:

* Collection endpoints (create, list) moved from `/forward/secrets` to `/secrets`.
* Item endpoints (`PATCH`, `DELETE`) moved from `/forward/secrets/{name}` to `/secrets/{name}`.
* `src/config.js` keeps a single Forward host root (`FORWARD_SANDBOX_URL` / `FORWARD_LIVE_URL`) with no trailing slash, and `ForwardClient` appends the `forward` and `secrets` path segments explicitly, matching every other SDK. Forward request URLs themselves are unchanged.
* Unit tests updated accordingly. (`src/api/forward/forward.js`, `src/config.js`, `test/forward/forward-unit.js`)

Anyone calling the secrets methods will now hit the new paths, so this is worth calling out in the release notes.

## Address Document Verification (Adv) endpoints

Implements the Adv family from swagger 2026-07-16: `POST`/`GET /address-document-verifications`, anonymize, attempts (create, list, get) and pdf-report.

* New `src/api/identities/address-document-verifications.js`, wired into the identities client. (`src/api/identities/identities.js`)
* TypeScript definitions added. (`types/dist/api/identities/address-document-verifications.d.ts`, `types/dist/api/identities/identities.d.ts`)
* Unit tests under `test/identities/address-document-verifications/`.

## Challenge indicator documentation alignment

Clarifies the allowed values of `3ds.challenge_indicator` per endpoint. No runtime behaviour changes here, only JSDoc plus a new test.

* Documented in `hosted-payments.js`, `payments-links.js`, `payment-sessions.js` and `payments.js` that the field accepts only the four standard values (`no_preference`, `no_challenge_requested`, `challenge_requested`, `challenge_requested_mandate`), and that exemption values are not accepted on these endpoints.
* Documented in `sessions.js` that `challenge_indicator` uniquely accepts all nine values, including exemption requests, and explained the fallback behaviour when an exemption cannot be applied.
* Added `test/sessions/challenge-indicator.js` covering the accepted value sets.
