### PR TITLE
docs(payments): document ProcessingData response fields on GET /payments/{id}

### DIFF
--- a/src/api/payments/payments.js
+++ b/src/api/payments/payments.js
@@ -114,6 +114,17 @@ export default class Payments {
     /**
      * Returns the details of the payment with the specified identifier string.
      *
+     * Response fields available under `processing` (pass-through, swagger ProcessingData):
+     *  - scheme — the scheme on which the payment was authorized, which may differ from the
+     *    card's scheme if the card is co-badged (2026-06-02)
+     *  - partner_fraud_status — partner fraud status; if `Pending` and the merchant captures
+     *    before it changes to `Accepted`, the transaction risk is solely on the merchant
+     *  - partner_merchant_advice_code — Mastercard Merchant Advice Code (MAC), with retry
+     *    guidance for declined transactions
+     *  - scheme_transaction_link_id (Mastercard Transaction Link Identifier, 2026-06-08)
+     *  - failure_code, partner_code, partner_response_code (2026-05-08)
+     *  - fallback_source_used (2026-04-23)
+     *
      * @memberof Payments
      * @param {string} id /^(pay|sid)_(\w{26})$/ The payment or payment session identifier.
      * @return {Promise<Object>} A promise to the get payment response.


### PR DESCRIPTION
**Summary**

Documents the response-only `processing` fields `scheme`, `partner_fraud_status` and `partner_merchant_advice_code` on `Payments.get`, aligning the Node SDK with the swagger `ProcessingData` schema (INT-1668).

The Node SDK returns the raw API JSON (`Promise<Object>`) and does not model response payloads, so the JSDoc pass-through block is the discoverability surface for response fields. This follows the pattern already used on `Payments.request`.

**Changes**
- `src/api/payments/payments.js` — added a `processing` pass-through block to the `Payments.get` JSDoc listing `scheme`, `partner_fraud_status`, `partner_merchant_advice_code`, plus the previously undocumented `scheme_transaction_link_id`, `failure_code`, `partner_code`, `partner_response_code` and `fallback_source_used`

**API Reference**
- `GET /payments/{id}` — `PaymentDetails.processing` (`ProcessingData` schema)

**Breaking changes**

None. Documentation only, no runtime change.

**README**

No impact. The README does not document individual response fields.