### PR TITLE
feat(payments): document and type optional amount on payment voids

### DIFF
--- a/src/api/payments/payments.js
+++ b/src/api/payments/payments.js
@@ -301,6 +301,7 @@ export default class Payments {
      * @memberof Payments
      * @param {string} paymentId /^(pay)_(\w{26})$/ The payment or payment session identifier.
      * @param {Object} [body] Void request body.
+     * @param {number} [body.amount] The amount to void, in the minor currency unit (min 0, max 9999999999). If not specified, the full payment amount is voided.
      * @param {string} [idempotencyKey] Idempotency Key.
      * @return {Promise<Object>} A promise to the void response.
      */

--- a/test/payments/voidPayment.js
+++ b/test/payments/voidPayment.js
@@ -208,6 +208,58 @@ describe('Void a payment', () => {
         expect(refund.reference).to.equal('VOID');
     });
 
+    it('should void payment partially with an amount in the body', async () => {
+        nock('https://123456789.api.sandbox.checkout.com')
+            .post(
+                '/payments/pay_6ndp5facelxurne7gloxkxm57u/voids',
+                (requestBody) =>
+                    requestBody.amount === 50 &&
+                    requestBody.reference === 'PARTIAL-VOID'
+            )
+            .reply(202, {
+                action_id: 'act_3cxabwfq4ieu3mn3cuzv7ct6dy',
+                reference: 'PARTIAL-VOID',
+                _links: {
+                    payment: {
+                        href: 'https://123456789.api.sandbox.checkout.com/payments/pay_6ndp5facelxurne7gloxkxm57u',
+                    },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+
+        const voids = await cko.payments.void('pay_6ndp5facelxurne7gloxkxm57u', {
+            amount: 50,
+            reference: 'PARTIAL-VOID',
+        });
+
+        expect(voids.reference).to.equal('PARTIAL-VOID');
+    });
+
+    it('should not send an amount when void is called without a body', async () => {
+        nock('https://123456789.api.sandbox.checkout.com')
+            .post(
+                '/payments/pay_6ndp5facelxurne7gloxkxm57u/voids',
+                (requestBody) =>
+                    !requestBody || requestBody.amount === undefined
+            )
+            .reply(202, {
+                action_id: 'act_hvue5c7klzmubkfmxfptldibdi',
+                reference: 'FULL-VOID',
+                _links: {
+                    payment: {
+                        href: 'https://123456789.api.sandbox.checkout.com/payments/pay_6ndp5facelxurne7gloxkxm57u',
+                    },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+
+        const voids = await cko.payments.void('pay_6ndp5facelxurne7gloxkxm57u');
+
+        expect(voids.reference).to.equal('FULL-VOID');
+    });
+
     it('should throw AuthenticationError', async () => {
         nock('https://123456789.api.sandbox.checkout.com')
             .post('/payments/pay_7enxra4adw6evgalvfabl6nbqy/voids')


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.