### PR TITLE
feat(accounts): document ISV payout schedule fields and response links

### DIFF
--- a/src/api/hosted-payments/hosted-payments.js
+++ b/src/api/hosted-payments/hosted-payments.js
@@ -48,6 +48,10 @@ export default class HostedPayments {
     /**
      * Get Hosted Payments Page details
      *
+     * The response (swagger GetHostedPaymentsResponse) includes a `_links`
+     * object with `self` and `redirect` links, plus `payment` and
+     * `payment_actions` once a payment is in progress or completed.
+     *
      * @memberof HostedPayments
      * @param {string} id - Hosted payment id
      * @return {Promise<Object>} A promise to the Hosted Payment response.

--- a/src/api/payments-links/payments-links.js
+++ b/src/api/payments-links/payments-links.js
@@ -49,6 +49,10 @@ export default class PaymentLinks {
     /**
      * Retrieve details about a specific Payment Link using its ID returned when the link was created. In the response, you will see the status of the Payment Link.
      *
+     * The response (swagger GetPaymentLinkResponse) includes a `_links`
+     * object with `self` and `redirect` links, plus `payment` and
+     * `payment_actions` once a payment is in progress or completed.
+     *
      * @memberof PaymentLinks
      * @param {string} id
      * @return {Promise<Object>} A promise to the Payment Link response.

--- a/src/api/platforms/payment-instruments.js
+++ b/src/api/platforms/payment-instruments.js
@@ -82,6 +82,16 @@ export default class PaymentInstruments {
     /**
      * Add a payment instrument to a sub-entity.
      *
+     * Request body (swagger PlatformsPaymentInstrumentCreate, 2026-08-05),
+     * all fields required:
+     *  - type - the type of instrument, for example `bank_account`.
+     *  - label - a reference that you can use to identify the payment
+     *    instrument.
+     *  - currency - the three-letter ISO currency code of the account's
+     *    currency.
+     *  - instrument_details - details of the payment instrument being
+     *    created.
+     *
      * @param {string} id Sub-entity id.
      * @param {Object} body Platforms request body.
      * @return {Promise<Object>} A promise to the Platforms response.

--- a/src/api/platforms/payout-schedules.js
+++ b/src/api/platforms/payout-schedules.js
@@ -15,6 +15,17 @@ export default class PayoutSchedules {
     /**
      * Retrieve information about a sub-entity's payout schedule.
      *
+     * The response is keyed by currency code. For SaaS sellers (swagger
+     * GetScheduleResponseIsv, 2026-08-05) each currency entry's `recurrence`
+     * also includes:
+     *  - recurrence.balance_minimum - amount, in the minor units of the
+     *    schedule's currency, retained in the sub-entity's available balance.
+     *  - recurrence.carry_forward_enabled - whether any balance below the
+     *    configured minimum is carried forward to the next payout.
+     *  - payment_instrument_id - the ID of the platforms payment instrument
+     *    used as the payout destination.
+     * Each currency entry also contains a `_links` object.
+     *
      * @param {string} id The sub-entity's ID.
      * @return {Promise<Object>} A promise to the Platforms response.
      */
@@ -34,6 +45,19 @@ export default class PayoutSchedules {
 
     /**
      * Update a sub-entity's payout schedule.
+     *
+     * The body is keyed by the three-letter ISO currency code. Each currency
+     * object requires `enabled` and `recurrence`, and accepts `threshold`.
+     * For SaaS sellers (swagger UpdateScheduleRequestIsv, 2026-08-05) each
+     * currency object also accepts:
+     *  - balance_minimum - amount, in the minor units of the schedule's
+     *    currency, to retain in the sub-entity's available balance. Defaults
+     *    to 0.
+     *  - carry_forward_enabled - whether to carry forward any balance below
+     *    the configured minimum to the next payout. Defaults to false.
+     *  - payment_instrument_id - the ID of the platforms payment instrument
+     *    used as the payout destination. Optional; if included it must
+     *    reference a verified payment instrument.
      *
      * @param {string} id The sub-entity's ID.
      * @param {Object} body Platforms request body.

--- a/test/hosted-payments/hosted-payments.js
+++ b/test/hosted-payments/hosted-payments.js
@@ -212,6 +212,31 @@ describe('Hosted Payments', () => {
         expect(hp.id).to.equal(id);
     });
 
+    it('should surface _links when getting a hosted payment', async () => {
+        nock('https://123456789.api.sandbox.checkout.com')
+            .get('/hosted-payments/hpp_kQhs_fI9b8oQ')
+            .reply(200, {
+                id: 'hpp_kQhs_fI9b8oQ',
+                status: 'Payment Pending',
+                _links: {
+                    self: {
+                        href: 'https://123456789.api.sandbox.checkout.com/hosted-payments/hpp_kQhs_fI9b8oQ',
+                    },
+                    redirect: { href: 'https://pay.sandbox.checkout.com/page/hpp_kQhs_fI9b8oQ' },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+        const hp = await cko.hostedPayments.get('hpp_kQhs_fI9b8oQ');
+
+        expect(hp._links.self.href).to.equal(
+            'https://123456789.api.sandbox.checkout.com/hosted-payments/hpp_kQhs_fI9b8oQ'
+        );
+        expect(hp._links.redirect.href).to.equal(
+            'https://pay.sandbox.checkout.com/page/hpp_kQhs_fI9b8oQ'
+        );
+    });
+
     it('should throw Authentication Error', async () => {
         nock('https://123456789.api.sandbox.checkout.com')
             .get('/hosted-payments/hpp_kQhs_fI9b8oQ')

--- a/test/payments-links/payments-links.js
+++ b/test/payments-links/payments-links.js
@@ -235,6 +235,31 @@ describe('Payment Links', () => {
         let getResponse = await cko.paymentLinks.get(linksResponse.id);
     });
 
+    it('should surface _links when getting a payment link', async () => {
+        nock('https://123456789.api.sandbox.checkout.com')
+            .get('/payment-links/pl_irx_SMlY5RCA')
+            .reply(200, {
+                id: 'pl_irx_SMlY5RCA',
+                status: 'Active',
+                _links: {
+                    self: {
+                        href: 'https://123456789.api.sandbox.checkout.com/payment-links/pl_irx_SMlY5RCA',
+                    },
+                    redirect: { href: 'https://pay.sandbox.checkout.com/link/pl_irx_SMlY5RCA' },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+        const linkDetails = await cko.paymentLinks.get('pl_irx_SMlY5RCA');
+
+        expect(linkDetails._links.self.href).to.equal(
+            'https://123456789.api.sandbox.checkout.com/payment-links/pl_irx_SMlY5RCA'
+        );
+        expect(linkDetails._links.redirect.href).to.equal(
+            'https://pay.sandbox.checkout.com/link/pl_irx_SMlY5RCA'
+        );
+    });
+
     it('should get the payment link status', async () => {
         nock('https://123456789.api.sandbox.checkout.com')
             .post('/payment-links')

--- a/test/platforms/payment-instruments/payment-instruments-unit.js
+++ b/test/platforms/payment-instruments/payment-instruments-unit.js
@@ -246,6 +246,49 @@ describe('Platforms - Payment Instruments', () => {
         expect(instrument.id).to.equal('ppi_goaxfhavh5ztwdf662mnii6zem');
     });
 
+    it('should pass through label, currency and instrument_details when adding a payment instrument', async () => {
+        nock('https://123456789.access.sandbox.checkout.com').post('/connect/token').reply(201, {
+            access_token: '1234',
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'flow',
+        });
+        let capturedBody;
+        nock('https://123456789.api.sandbox.checkout.com')
+            .post(
+                '/accounts/entities/ent_aneh5mtyobxzazriwuevngrz6y/payment-instruments',
+                (body) => {
+                    capturedBody = body;
+                    return true;
+                }
+            )
+            .reply(201, {
+                id: 'ppi_goaxfhavh5ztwdf662mnii6zem',
+            });
+
+        let cko = new Checkout(platforms_secret, {
+            client: platforms_ack,
+            scope: ['accounts'],
+            environment: 'sandbox',
+            subdomain: '123456789',
+        });
+
+        await cko.platforms.addPaymentInstrument('ent_aneh5mtyobxzazriwuevngrz6y', {
+            label: "Peter's Personal Account",
+            type: 'bank_account',
+            currency: 'GBP',
+            instrument_details: {
+                account_number: '12345678',
+                bank_code: '050389',
+            },
+        });
+
+        expect(capturedBody.label).to.equal("Peter's Personal Account");
+        expect(capturedBody.currency).to.equal('GBP');
+        expect(capturedBody.instrument_details.account_number).to.equal('12345678');
+        expect(capturedBody.instrument_details.bank_code).to.equal('050389');
+    });
+
     it('should throw AuthenticationError when creating a payment instrument [deprecated]', async () => {
         nock('https://123456789.access.sandbox.checkout.com').post('/connect/token').reply(201, {
             access_token: '1234',

--- a/test/platforms/payout-schedules/payout-schedules-unit.js
+++ b/test/platforms/payout-schedules/payout-schedules-unit.js
@@ -183,4 +183,74 @@ describe('Platforms - Payout Schedules', () => {
         expect(response).to.not.be.null;
         expect(response.frequency).to.equal("weekly");
     });
+
+    it('should pass through ISV fields when updating a payout schedule', async () => {
+        let capturedBody;
+        nock('https://123456789.api.sandbox.checkout.com')
+            .put('/accounts/entities/ent_123/payout-schedules', (body) => {
+                capturedBody = body;
+                return true;
+            })
+            .reply(200, {
+                _links: {
+                    self: {
+                        href: 'https://123456789.api.checkout.com/accounts/entities/ent_123',
+                    },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+        await cko.platforms.updateSubEntityPayoutSchedule('ent_123', {
+            GBP: {
+                enabled: true,
+                threshold: 100,
+                balance_minimum: 500,
+                carry_forward_enabled: true,
+                payment_instrument_id: 'ppi_w4jelhppmfiufdnatam37wrfc4',
+                recurrence: {
+                    frequency: 'weekly',
+                    by_day: ['monday'],
+                },
+            },
+        });
+
+        expect(capturedBody.GBP.balance_minimum).to.equal(500);
+        expect(capturedBody.GBP.carry_forward_enabled).to.equal(true);
+        expect(capturedBody.GBP.payment_instrument_id).to.equal(
+            'ppi_w4jelhppmfiufdnatam37wrfc4'
+        );
+    });
+
+    it('should surface ISV fields when retrieving a payout schedule', async () => {
+        nock('https://123456789.api.sandbox.checkout.com')
+            .get('/accounts/entities/ent_123/payout-schedules')
+            .reply(200, {
+                GBP: {
+                    enabled: true,
+                    payment_instrument_id: 'ppi_w4jelhppmfiufdnatam37wrfc4',
+                    recurrence: {
+                        frequency: 'weekly',
+                        by_day: ['monday'],
+                        threshold: 100,
+                        balance_minimum: 500,
+                        carry_forward_enabled: true,
+                    },
+                    _links: {
+                        self: {
+                            href: 'https://123456789.api.checkout.com/accounts/entities/ent_123',
+                        },
+                    },
+                },
+            });
+
+        const cko = new Checkout(SK, { subdomain: '123456789' });
+        const response = await cko.platforms.retrieveSubEntityPayoutSchedule('ent_123');
+
+        expect(response.GBP.payment_instrument_id).to.equal(
+            'ppi_w4jelhppmfiufdnatam37wrfc4'
+        );
+        expect(response.GBP.recurrence.balance_minimum).to.equal(500);
+        expect(response.GBP.recurrence.carry_forward_enabled).to.equal(true);
+        expect(response.GBP._links.self.href).to.be.a('string');
+    });
 });


### PR DESCRIPTION
**Summary**
Adds the 2026-08-05 spec changes: the ISV (SaaS seller) payout schedule fields `balance_minimum` and `carry_forward_enabled`, plus `payment_instrument_id` which was present in the spec but missing from the SDK. Includes characterization tests pinning the payout schedule GET response shape and frequency serialization the API actually uses.

**Changes**
- Payout schedule request/response models: new optional `balance_minimum`, `carry_forward_enabled`, `payment_instrument_id`
- ISV constraints documented on the existing frequency types (working days only for weekly and daily; monthly accepts only [1], [15], [1,15] or [1,16]); no parallel Isv classes because the wire format is identical
- Serialization tests: fields present when set, absent when unset; spec-shape characterization tests

**API Reference**
- `GET /accounts/entities/{id}/payout-schedules`
- `PUT /accounts/entities/{id}/payout-schedules`

**Breaking changes**
None.

**README**
No README impact.