### PR TITLE
Release 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-sdk-node",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Official Node.js SDK for Checkout.com payment gateway - Full API coverage with TypeScript support",
   "type": "module",
   "engines": {


### PR DESCRIPTION
- The merchant-specific subdomain option is now required. Set it, or pass useLegacyDomain to keep using the shared checkout.com hosts (#448)
- An invalid subdomain now throws instead of being silently ignored, including on the exported EnvironmentSubdomain class (#448)
- Document optional amount on payment voids to support partial voids (#449)
- Document the ISV (SaaS seller) payout schedule fields balance_minimum, carry_forward_enabled and payment_instrument_id (#450)